### PR TITLE
Feature/aura instrumentation

### DIFF
--- a/messages/rflib.logging.aura.instrument.md
+++ b/messages/rflib.logging.aura.instrument.md
@@ -1,0 +1,20 @@
+# summary
+
+Summary of a command.
+
+# description
+
+More information about a command. Don't repeat the summary. 
+
+# flags.name.summary
+
+Description of a flag.
+
+# flags.name.description
+
+More information about a flag. Don't repeat the summary. 
+
+# examples
+
+- <%= config.bin %> <%= command.id %>
+

--- a/messages/rflib.logging.aura.instrument.md
+++ b/messages/rflib.logging.aura.instrument.md
@@ -1,20 +1,64 @@
 # summary
 
-Summary of a command.
+Instrument Lightning Web Components with RFLIB logging statements automatically.
 
 # description
 
-More information about a command. Don't repeat the summary. 
+Analyzes Lightning Web Component JavaScript files and adds RFLIB logging statements for:
+- Method entry logging with parameter values
+- Error logging in try-catch blocks
+- Error logging in Promise catch handlers
+- Condition logging in if/else blocks
+- Adds logger import if not present
+- Adds logger initialization if not present
+- Formats modified files using Prettier (optional)
 
-# flags.name.summary
+# flags.sourcepath.summary
 
-Description of a flag.
+Directory containing aura JavaScript files to instrument with logging.
 
-# flags.name.description
+# flags.sourcepath.description
 
-More information about a flag. Don't repeat the summary. 
+Path to the source directory containing Lightning Web Component JavaScript files that should be instrumented with RFLIB logging statements. Aura component files are automatically excluded. The command will:
+- Process all .js files in the directory and subdirectories
+- Skip files in 'aura' directories
+- Add import statement: import { createLogger } from 'c/rflibLogger'
+- Add logger initialization: const logger = createLogger('ComponentName')
+
+# flags.dryrun.summary
+
+Preview changes without modifying files.
+
+# flags.dryrun.description
+
+When enabled, shows which files would be modified without making actual changes. Useful for reviewing the impact before applying changes. Shows:
+- Files that would be modified
+- Number of processed files
+- Number of modified files
+- Number of formatted files
+
+# flags.prettier.summary
+
+Format modified files using Prettier.
+
+# flags.prettier.description
+
+When enabled, formats the modified JavaScript files using Prettier after adding logging statements. Maintains consistent code style with:
+- 120 character line width
+- 4 space indentation
+- Single quotes for strings
+- No tabs
 
 # examples
 
-- <%= config.bin %> <%= command.id %>
+- Add logging to all aura files:
+$ sf rflib logging aura instrument --sourcepath force-app/main/default/aura
 
+- Preview changes:
+$ sf rflib logging aura instrument --sourcepath force-app/main/default/aura --dryrun
+
+- Add logging and format code:
+$ sf rflib logging aura instrument --sourcepath force-app/main/default/aura --prettier
+
+- Process specific component:
+$ sf rflib logging aura instrument --sourcepath force-app/main/default/aura/myComponent

--- a/messages/rflib.logging.aura.instrument.md
+++ b/messages/rflib.logging.aura.instrument.md
@@ -1,29 +1,34 @@
 # summary
 
-Instrument Lightning Web Components with RFLIB logging statements automatically.
+Instrument Aura Components with RFLIB logging statements automatically.
 
 # description
 
-Analyzes Lightning Web Component JavaScript files and adds RFLIB logging statements for:
-- Method entry logging with parameter values
+Analyzes Aura Component files and adds RFLIB logging statements for:
+- Method entry logging with parameter values in Controller, Helper, and Renderer files
 - Error logging in try-catch blocks
 - Error logging in Promise catch handlers
-- Condition logging in if/else blocks
-- Adds logger import if not present
-- Adds logger initialization if not present
+- Adds rflibLoggerCmp component if not present
 - Formats modified files using Prettier (optional)
+
+The command processes:
+- Component (.cmp) files to add the logger component
+- Controller (.js) files for method instrumentation
+- Helper (.js) files for method instrumentation
+- Renderer (.js) files for method instrumentation
 
 # flags.sourcepath.summary
 
-Directory containing aura JavaScript files to instrument with logging.
+Directory containing Aura components to instrument with logging.
 
 # flags.sourcepath.description
 
-Path to the source directory containing Lightning Web Component JavaScript files that should be instrumented with RFLIB logging statements. Aura component files are automatically excluded. The command will:
-- Process all .js files in the directory and subdirectories
-- Skip files in 'aura' directories
-- Add import statement: import { createLogger } from 'c/rflibLogger'
-- Add logger initialization: const logger = createLogger('ComponentName')
+Path to the source directory containing Aura components that should be instrumented with RFLIB logging statements. The command will:
+- Scan for 'aura' directories recursively
+- Process all Aura components found
+- Add <c:rflibLoggerCmp> to component files
+- Add logging statements to JavaScript files
+- Initialize logger in methods using component.find()
 
 # flags.dryrun.summary
 
@@ -48,17 +53,18 @@ When enabled, formats the modified JavaScript files using Prettier after adding 
 - 4 space indentation
 - Single quotes for strings
 - No tabs
+- No trailing commas
 
 # examples
 
 - Add logging to all aura files:
-$ sf rflib logging aura instrument --sourcepath force-app/main/default/aura
+$ sf rflib logging aura instrument --sourcepath force-app
 
 - Preview changes:
-$ sf rflib logging aura instrument --sourcepath force-app/main/default/aura --dryrun
+$ sf rflib logging aura instrument --sourcepath force-app --dryrun
 
 - Add logging and format code:
-$ sf rflib logging aura instrument --sourcepath force-app/main/default/aura --prettier
+$ sf rflib logging aura instrument --sourcepath force-app --prettier
 
 - Process specific component:
 $ sf rflib logging aura instrument --sourcepath force-app/main/default/aura/myComponent

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
               },
               "lwc": {
                 "description": "description for rflib.logging.lwc"
+              },
+              "aura": {
+                "description": "description for rflib.logging.aura"
               }
             }
           }

--- a/src/commands/rflib/logging/aura/instrument.ts
+++ b/src/commands/rflib/logging/aura/instrument.ts
@@ -1,0 +1,36 @@
+
+
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+const messages = Messages.loadMessages('rflib-plugin', 'rflib.logging.aura.instrument');
+
+export type RflibLoggingAuraInstrumentResult = {
+  path: string;
+};
+
+export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAuraInstrumentResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+
+  public static readonly flags = {
+    name: Flags.string({
+      summary: messages.getMessage('flags.name.summary'),
+      description: messages.getMessage('flags.name.description'),
+      char: 'n',
+      required: false,
+    }),
+  };
+
+  public async run(): Promise<RflibLoggingAuraInstrumentResult> {
+    const { flags } = await this.parse(RflibLoggingAuraInstrument);
+
+    const name = flags.name ?? 'world';
+    this.log(`hello ${name} from src/commands/rflib/logging/aura/instrument.ts`);
+    return {
+      path: 'src/commands/rflib/logging/aura/instrument.ts',
+    };
+  }
+}

--- a/src/commands/rflib/logging/aura/instrument.ts
+++ b/src/commands/rflib/logging/aura/instrument.ts
@@ -101,7 +101,7 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
 
   private static processPromiseChains(content: string): string {
     return content.replace(promiseChainRegex, (match, type, param, blockBody, singleLineBody) => {
-      const paramName = param?.trim() || (type === 'then' ? 'result' : 'error');
+      const paramName = (param as string | undefined)?.trim() || (type === 'then' ? 'result' : 'error');
 
       let logStatement = '';
       switch (type) {
@@ -234,7 +234,7 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
 
     const lastAttributeMatch = [...content.matchAll(attributeRegex)].pop();
     if (lastAttributeMatch) {
-      const insertPosition = lastAttributeMatch.index! + lastAttributeMatch[0].length;
+      const insertPosition = lastAttributeMatch.index + lastAttributeMatch[0].length;
       const loggerComponent = `\n    <c:rflibLoggerCmp aura:id="logger" name="${componentName}" appendComponentId="false" />`;
       content = content.slice(0, insertPosition) + loggerComponent + content.slice(insertPosition);
     }

--- a/src/commands/rflib/logging/aura/instrument.ts
+++ b/src/commands/rflib/logging/aura/instrument.ts
@@ -169,6 +169,16 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
 
   private async processDirectory(dirPath: string, isDryRun: boolean, usePrettier: boolean): Promise<void> {
     this.logger.debug(`Processing directory: ${dirPath}`);
+
+    // Check if path is direct component
+    const dirName = path.basename(dirPath);
+    const parentDir = path.basename(path.dirname(dirPath));
+    if (parentDir === 'aura') {
+      this.logger.info(`Processing single component: ${dirName}`);
+      await this.processAuraComponent(dirPath, dirName, isDryRun, usePrettier);
+      return;
+    }
+
     const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
 
     for (const entry of entries) {
@@ -187,6 +197,12 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
   }
 
   private async processAuraComponents(auraPath: string, isDryRun: boolean, usePrettier: boolean): Promise<void> {
+    // Check if path is already an aura directory
+    if (path.basename(auraPath) !== 'aura') {
+      this.logger.warn(`Not an aura directory: ${auraPath}`);
+      return;
+    }
+
     const entries = await fs.promises.readdir(auraPath, { withFileTypes: true });
 
     for (const entry of entries) {

--- a/src/commands/rflib/logging/aura/instrument.ts
+++ b/src/commands/rflib/logging/aura/instrument.ts
@@ -1,13 +1,27 @@
-
-
+/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable @typescript-eslint/quotes */
+/* eslint-disable sf-plugin/no-missing-messages */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
-import { Messages } from '@salesforce/core';
+import { Messages, Logger } from '@salesforce/core';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as prettier from 'prettier';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('rflib-plugin', 'rflib.logging.aura.instrument');
 
+const loggerComponentRegex = /<c:rflibLoggerCmp\s+aura:id="([^"]+)"\s+name="([^"]+)"\s+appendComponentId="([^"]+)"\s*\/>/;
+const attributeRegex = /<aura:attribute[^>]*>/g;
+const methodRegex = /(\b\w+)\s*:\s*function\s*\((.*?)\)\s*{((?:[^{}]|{(?:[^{}]|{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})*})*?)}/g;
+const promiseChainRegex = /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:{([\s\S]*?)}|([^{].*?)(?=\.|\)|\n|;|$))/g;
+const tryCatchBlockRegex = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
+
 export type RflibLoggingAuraInstrumentResult = {
-  path: string;
+  processedFiles: number;
+  modifiedFiles: number;
+  formattedFiles: number;
 };
 
 export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAuraInstrumentResult> {
@@ -16,21 +30,234 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
   public static readonly examples = messages.getMessages('examples');
 
   public static readonly flags = {
-    name: Flags.string({
-      summary: messages.getMessage('flags.name.summary'),
-      description: messages.getMessage('flags.name.description'),
-      char: 'n',
-      required: false,
+    sourcepath: Flags.string({
+      char: 's',
+      required: true,
+      summary: messages.getMessage('flags.sourcepath.summary'),
+      description: messages.getMessage('flags.sourcepath.description'),
+    }),
+    dryrun: Flags.boolean({
+      char: 'd',
+      default: false,
+      summary: messages.getMessage('flags.dryrun.summary'),
+      description: messages.getMessage('flags.dryrun.description'),
+    }),
+    prettier: Flags.boolean({
+      char: 'p',
+      default: false,
+      summary: messages.getMessage('flags.prettier.summary'),
+      description: messages.getMessage('flags.prettier.description'),
     }),
   };
 
+  private logger!: Logger;
+  private processedFiles = 0;
+  private modifiedFiles = 0;
+  private formattedFiles = 0;
+
+  private readonly prettierConfig: prettier.Options = {
+    parser: 'babel',
+    printWidth: 120,
+    tabWidth: 4,
+    useTabs: false,
+    singleQuote: true,
+  };
+
+  private static processMethodLogging(content: string): string {
+    return content.replace(methodRegex, (match: string, methodName: string, args: string) => {
+      const parameters = args.split(',').map(p => p.trim()).filter(p => p);
+      const logArgs = parameters.length > 0 ? `, ${parameters.join(', ')}` : '';
+
+      return `${match}
+        logger.info('${methodName}(${parameters.map((_, i) => `{${i}}`).join(', ')})'${logArgs});`;
+    });
+  }
+
+  private static processPromiseChains(content: string): string {
+    return content.replace(promiseChainRegex, (match, type, param, blockBody, singleLineBody) => {
+      const paramName = param?.trim() || (type === 'then' ? 'result' : 'error');
+
+      let logStatement = '';
+      switch (type) {
+        case 'then':
+          logStatement = `logger.info('Promise resolved. Result={0}', ${paramName});`;
+          break;
+        case 'catch':
+          logStatement = `logger.error('An error occurred', ${paramName});`;
+          break;
+        case 'finally':
+          logStatement = `logger.info('Promise chain completed');`;
+          break;
+      }
+
+      if (singleLineBody) {
+        return `.${type}(${param || paramName} => {
+          ${logStatement}
+          return ${singleLineBody};
+        })`;
+      }
+
+      if (blockBody) {
+        return `.${type}(${param || paramName} => {
+          ${logStatement}${blockBody}
+        })`;
+      }
+
+      return match;
+    });
+  }
+
+  private static processTryCatchBlocks(content: string): string {
+    return content.replace(tryCatchBlockRegex, (match: string, exceptionVar: string) => {
+      const errorVar = exceptionVar.trim().split(' ')[0] || 'error';
+
+      return match.replace(/catch\s*\(([^)]*)\)\s*{/,
+        `catch(${exceptionVar}) {
+          logger.error('An error occurred', ${errorVar});`
+      );
+    });
+  }
+
   public async run(): Promise<RflibLoggingAuraInstrumentResult> {
+    this.logger = await Logger.child(this.ctor.name);
     const { flags } = await this.parse(RflibLoggingAuraInstrument);
 
-    const name = flags.name ?? 'world';
-    this.log(`hello ${name} from src/commands/rflib/logging/aura/instrument.ts`);
+    this.logger.info(`Starting Aura component instrumentation in ${flags.sourcepath}`);
+    this.logger.debug(`Dry run mode: ${flags.dryrun}`);
+
+    await this.processDirectory(flags.sourcepath, flags.dryrun, flags.prettier);
+
+    this.logger.info('Instrumentation complete');
+    this.logger.info(`Stats: processed=${this.processedFiles}, modified=${this.modifiedFiles}`);
+
     return {
-      path: 'src/commands/rflib/logging/aura/instrument.ts',
+      processedFiles: this.processedFiles,
+      modifiedFiles: this.modifiedFiles,
+      formattedFiles: this.formattedFiles,
     };
+  }
+
+  private async processDirectory(dirPath: string, isDryRun: boolean, usePrettier: boolean): Promise<void> {
+    this.logger.debug(`Processing directory: ${dirPath}`);
+    const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      this.logger.debug(`Examining entry: ${entry.name}`);
+
+      if (entry.isDirectory()) {
+        if (entry.name === 'aura') {
+          this.logger.info(`Found Aura directory: ${fullPath}`);
+          await this.processAuraComponents(fullPath, isDryRun, usePrettier);
+        } else {
+          await this.processDirectory(fullPath, isDryRun, usePrettier);
+        }
+      }
+    }
+  }
+
+  private async processAuraComponents(auraPath: string, isDryRun: boolean, usePrettier: boolean): Promise<void> {
+    const entries = await fs.promises.readdir(auraPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const componentPath = path.join(auraPath, entry.name);
+        await this.processAuraComponent(componentPath, entry.name, isDryRun, usePrettier);
+      }
+    }
+  }
+
+  private async processAuraComponent(componentPath: string, componentName: string, isDryRun: boolean, usePrettier: boolean): Promise<void> {
+    this.logger.info(`Processing Aura component: ${componentName}`);
+    const cmpPath = path.join(componentPath, `${componentName}.cmp`);
+    const controllerPath = path.join(componentPath, `${componentName}Controller.js`);
+    const helperPath = path.join(componentPath, `${componentName}Helper.js`);
+
+    try {
+      const loggerId = await this.instrumentCmpFile(cmpPath, componentName, isDryRun);
+      this.logger.debug(`Using logger ID: ${loggerId}`);
+
+      await this.instrumentJsFile(controllerPath, loggerId, isDryRun, usePrettier);
+      await this.instrumentJsFile(helperPath, loggerId, isDryRun, usePrettier);
+    } catch (error) {
+      this.logger.error(`Error processing Aura ${componentName}`, error);
+    }
+  }
+
+  private async instrumentCmpFile(filePath: string, componentName: string, isDryRun: boolean): Promise<string> {
+    if (!fs.existsSync(filePath)) {
+      this.logger.warn(`Component file not found: ${filePath}`);
+      return 'logger';
+    }
+
+    this.logger.debug(`Instrumenting component file: ${filePath}`);
+    this.processedFiles++;
+    let content = await fs.promises.readFile(filePath, 'utf8');
+    const originalContent = content;
+
+    const loggerMatch = content.match(loggerComponentRegex);
+    if (loggerMatch) {
+      return loggerMatch[1];
+    }
+
+    const lastAttributeMatch = [...content.matchAll(attributeRegex)].pop();
+    if (lastAttributeMatch) {
+      const insertPosition = lastAttributeMatch.index! + lastAttributeMatch[0].length;
+      const loggerComponent = `\n    <c:rflibLoggerCmp aura:id="logger" name="${componentName}" appendComponentId="false" />`;
+      content = content.slice(0, insertPosition) + loggerComponent + content.slice(insertPosition);
+    }
+
+    if (content !== originalContent && !isDryRun) {
+      await fs.promises.writeFile(filePath, content, 'utf8');
+      this.modifiedFiles++;
+    }
+
+    return 'logger';
+  }
+
+  private async instrumentJsFile(filePath: string, loggerId: string, isDryRun: boolean, usePrettier: boolean): Promise<void> {
+    if (!fs.existsSync(filePath)) {
+      this.logger.debug(`JavaScript file not found: ${filePath}`);
+      return;
+    }
+
+    this.logger.debug(`Instrumenting JavaScript file: ${filePath}`);
+    this.processedFiles++;
+    let content = await fs.promises.readFile(filePath, 'utf8');
+    const originalContent = content;
+
+    // Add logger initialization if not present
+    if (!content.includes(`var logger = component.find('${loggerId}')`)) {
+      const loggerInit = `\n    var logger = component.find('${loggerId}');\n`;
+      content = loggerInit + content;
+    }
+
+    // Process methods
+    content = RflibLoggingAuraInstrument.processMethodLogging(content);
+    content = RflibLoggingAuraInstrument.processPromiseChains(content);
+    content = RflibLoggingAuraInstrument.processTryCatchBlocks(content);
+
+    if (content !== originalContent) {
+      this.modifiedFiles++;
+      if (!isDryRun) {
+        try {
+          const finalContent = usePrettier ? await prettier.format(content, this.prettierConfig) : content;
+          await fs.promises.writeFile(filePath, finalContent);
+
+          if (usePrettier) {
+            this.formattedFiles++;
+            this.logger.info(`Modified and formatted: ${filePath}`);
+          } else {
+            this.logger.info(`Modified: ${filePath}`);
+          }
+        } catch (error) {
+          this.logger.warn(`Failed to format ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
+          await fs.promises.writeFile(filePath, content);
+          this.logger.info(`Modified without formatting: ${filePath}`);
+        }
+      } else {
+        this.logger.info(`Would modify: ${filePath}`);
+      }
+    }
   }
 }

--- a/src/commands/rflib/logging/aura/instrument.ts
+++ b/src/commands/rflib/logging/aura/instrument.ts
@@ -15,7 +15,7 @@ const messages = Messages.loadMessages('rflib-plugin', 'rflib.logging.aura.instr
 const loggerComponentRegex = /<c:rflibLoggerCmp\s+aura:id="([^"]+)"\s+name="([^"]+)"\s+appendComponentId="([^"]+)"\s*\/>/;
 const attributeRegex = /<aura:attribute[^>]*>/g;
 const loggerVarRegex = /var\s+(\w+)\s*=\s*component\.find\(['"](\w+)['"]\)/;
-const methodRegex = /(\b\w+)\s*:\s*function\s*\((.*?)\)\s*{((?:[^{}]|{(?:[^{}]|{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})*})*?)}/g;
+const methodRegex = /(\b\w+)\s*:\s*function\s*\((.*?)\)\s*{((?:[^{}]|{(?:[^{}]|{(?:[^{}]|{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})*})*})*?)}/g;
 const promiseChainRegex = /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:{([\s\S]*?)}|([^{].*?)(?=\.|\)|\n|;|$))/g;
 const tryCatchBlockRegex = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
 
@@ -65,10 +65,12 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
     trailingComma: "none"
   };
 
-  private static processMethodLogging(content: string, loggerId: string, filePath: string): string {
+  private static processMethodLogging(logger: Logger, content: string, loggerId: string, filePath: string): string {
     const isHelper = filePath.endsWith('Helper.js');
 
     return content.replace(methodRegex, (match: string, methodName: string, params: string, body: string) => {
+      logger.trace(`Processing method: ${methodName}`);
+
       const paramList = params.split(',').map(p => p.trim()).filter(p => p);
       let loggerVar = 'logger';
       let bodyContent = body;
@@ -257,7 +259,7 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
     const originalContent = content;
 
     // Process methods
-    content = RflibLoggingAuraInstrument.processMethodLogging(content, loggerId, filePath);
+    content = RflibLoggingAuraInstrument.processMethodLogging(this.logger, content, loggerId, filePath);
     content = RflibLoggingAuraInstrument.processPromiseChains(content);
     content = RflibLoggingAuraInstrument.processTryCatchBlocks(content);
 

--- a/src/commands/rflib/logging/aura/instrument.ts
+++ b/src/commands/rflib/logging/aura/instrument.ts
@@ -255,9 +255,11 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
       content = content.slice(0, insertPosition) + loggerComponent + content.slice(insertPosition);
     }
 
-    if (content !== originalContent && !isDryRun) {
-      await fs.promises.writeFile(filePath, content, 'utf8');
+    if (content !== originalContent) {
       this.modifiedFiles++;
+      if (!isDryRun) {
+        await fs.promises.writeFile(filePath, content, 'utf8');
+      }
     }
 
     return 'logger';

--- a/src/commands/rflib/logging/lwc/instrument.ts
+++ b/src/commands/rflib/logging/lwc/instrument.ts
@@ -18,7 +18,8 @@ const methodRegex = /(?:async\s+)?(?!(?:if|switch|case|while|for|catch)\b)(\b\w+
 const exportDefaultRegex = /export\s+default\s+class\s+(\w+)/;
 const ifStatementRegex = /if\s*\((.*?)\)\s*{([\s\S]*?)}|if\s*\((.*?)\)\s*([^{\n].*?)(?=\n|$)/g;
 const elseRegex = /}\s*else\s*{([\s\S]*?)}|}\s*else\s+([^{\n].*?)(?=\n|$)/g;
-const promiseChainRegex = /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:\{((?:[^{}]|`[^`]*`)*?)\}|([^{;]*(?:\([^)]*\))*)(?=(?:\)\))|\)|\.))/g;
+const promiseChainRegex =
+  /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:\{((?:[^{}]|`[^`]*`)*?)\}|([^{;]*(?:\([^)]*\))*)(?=(?:\)\))|\)|\.))/g;
 const tryCatchBlockRegex = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
 
 export type RflibLoggingLwcInstrumentResult = {
@@ -37,20 +38,20 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
       char: 's',
       required: true,
       summary: messages.getMessage('flags.sourcepath.summary'),
-      description: messages.getMessage('flags.sourcepath.description')
+      description: messages.getMessage('flags.sourcepath.description'),
     }),
     dryrun: Flags.boolean({
       char: 'd',
       default: false,
       summary: messages.getMessage('flags.dryrun.summary'),
-      description: messages.getMessage('flags.dryrun.description')
+      description: messages.getMessage('flags.dryrun.description'),
     }),
     prettier: Flags.boolean({
       char: 'p',
       default: false,
       summary: messages.getMessage('flags.prettier.summary'),
-      description: messages.getMessage('flags.prettier.description')
-    })
+      description: messages.getMessage('flags.prettier.description'),
+    }),
   };
 
   private logger!: Logger;
@@ -63,7 +64,7 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
     printWidth: 120,
     tabWidth: 4,
     useTabs: false,
-    singleQuote: true
+    singleQuote: true,
   };
 
   private static detectExistingImport(content: string): boolean {
@@ -74,7 +75,7 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
     const match = content.match(loggerRegex);
     return {
       exists: match !== null,
-      loggerName: match ? match[1] : 'logger'
+      loggerName: match ? match[1] : 'logger',
     };
   }
 
@@ -108,7 +109,8 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
 
     // First process if statements and store conditions
     let modified = content.replace(ifStatementRegex, (match, blockCondition, blockBody, lineCondition, lineBody) => {
-      const condition = typeof blockCondition === 'string' ? blockCondition : (typeof lineCondition === 'string' ? lineCondition : '');
+      const condition =
+        typeof blockCondition === 'string' ? blockCondition : typeof lineCondition === 'string' ? lineCondition : '';
       lastCondition = condition.trim();
       const logStatement = `${loggerName}.debug(\`if (${lastCondition})\`);`;
 
@@ -136,7 +138,10 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
   private static processMethodLogging(content: string, loggerName: string): string {
     // First handle methods
     let modified = content.replace(methodRegex, (match: string, methodName: string, args: string) => {
-      const parameters = args.split(',').map(p => p.trim()).filter(p => p);
+      const parameters = args
+        .split(',')
+        .map((p) => p.trim())
+        .filter((p) => p);
       const placeholders = parameters.map((_, i) => `{${i}}`).join(', ');
       const logArgs = parameters.length > 0 ? `, ${parameters.join(', ')}` : '';
 
@@ -152,7 +157,7 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
   private static processPromiseChains(content: string, loggerName: string): string {
     return content.replace(promiseChainRegex, (match, type, param, blockBody, singleLineBody, offset: number) => {
       const methodName = this.findEnclosingMethod(content, offset);
-      const paramName = typeof param === 'string' ? param.trim() : (type === 'then' ? 'result' : 'error');
+      const paramName = typeof param === 'string' ? param.trim() : type === 'then' ? 'result' : 'error';
       const indentation = match.match(/\n\s*/)?.[0] || '\n        ';
 
       let logStatement;
@@ -195,9 +200,10 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
       const methodName = this.findEnclosingMethod(content, offset);
       const errorVar = exceptionVar.trim().split(' ')[0] || 'error';
 
-      return match.replace(/catch\s*\(([^)]*)\)\s*{/,
+      return match.replace(
+        /catch\s*\(([^)]*)\)\s*{/,
         `catch(${exceptionVar}) {
-            ${loggerName}.error('An error occurred in function ${methodName}()', ${errorVar});`
+            ${loggerName}.error('An error occurred in function ${methodName}()', ${errorVar});`,
       );
     });
   }
@@ -218,7 +224,7 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
     return {
       processedFiles: this.processedFiles,
       modifiedFiles: this.modifiedFiles,
-      formattedFiles: this.formattedFiles
+      formattedFiles: this.formattedFiles,
     };
   }
 

--- a/src/commands/rflib/logging/lwc/instrument.ts
+++ b/src/commands/rflib/logging/lwc/instrument.ts
@@ -214,7 +214,9 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
 
     this.log(`Scanning LWC components in ${flags.sourcepath}...`);
 
+    this.spinner.start('Running...');
     await this.processDirectory(flags.sourcepath, flags.dryrun, flags.prettier);
+    this.spinner.stop();
 
     this.log(`\nInstrumentation complete.`);
     this.log(`Processed files: ${this.processedFiles}`);
@@ -237,7 +239,7 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
 
       if (stat.isDirectory()) {
         await this.processDirectory(filePath, isDryRun, usePrettier);
-      } else if (file.endsWith('.js') && !path.dirname(filePath).includes('aura')) {
+      } else if (file.endsWith('.js') && !path.dirname(filePath).includes('aura') && !path.dirname(filePath).includes('__tests__')) {
         await this.instrumentLwcFile(filePath, isDryRun, usePrettier);
       }
     }

--- a/test/commands/rflib/logging/aura/instrument.nut.ts
+++ b/test/commands/rflib/logging/aura/instrument.nut.ts
@@ -1,21 +1,109 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
+import { RflibLoggingAuraInstrumentResult } from '../../../../../src/commands/rflib/logging/aura/instrument.js';
+
+let testSession: TestSession;
 
 describe('rflib logging aura instrument NUTs', () => {
-  let session: TestSession;
+  before('prepare session', async () => {
+    testSession = await TestSession.create();
 
-  before(async () => {
-    session = await TestSession.create({ devhubAuthStrategy: 'NONE' });
+    const sampleCmp = `
+<aura:component>
+    <aura:attribute name="value" type="String" default="" />
+    <aura:attribute name="isValid" type="Boolean" default="false" />
+</aura:component>`;
+
+    const sampleController = `({
+    handleClick: function(component, event, helper) {
+        try {
+            helper.loadData(component);
+        } catch(error) {
+            console.error(error);
+        }
+    },
+    
+    processResult: function(component, event, helper) {
+        var data = event.getParam('data');
+        if (data.isValid) {
+            component.set("v.value", data.value);
+        }
+    }
+})`;
+
+    const sampleHelper = `({
+    loadData: function(component, params) {
+        var action = component.get("c.getData");
+        action.setParams(params);
+        action.setCallback(this, function(response) {
+            var state = response.getState();
+            if (state === "SUCCESS") {
+                component.set("v.value", response.getReturnValue());
+            }
+        });
+        $A.enqueueAction(action);
+    }
+})`;
+
+    const testDir = path.join(testSession.dir, 'force-app', 'main', 'default', 'aura', 'sampleComponent');
+    fs.mkdirSync(testDir, { recursive: true });
+    fs.writeFileSync(path.join(testDir, 'sampleComponent.cmp'), sampleCmp);
+    fs.writeFileSync(path.join(testDir, 'sampleComponentController.js'), sampleController);
+    fs.writeFileSync(path.join(testDir, 'sampleComponentHelper.js'), sampleHelper);
   });
 
   after(async () => {
-    await session?.clean();
+    await testSession?.clean();
   });
 
-  it('should display provided name', () => {
-    const name = 'World';
-    const command = `rflib logging aura instrument --name ${name}`;
-    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
-    expect(output).to.contain(name);
+  it('should process aura component in dry run mode', () => {
+    const result = execCmd<RflibLoggingAuraInstrumentResult>(
+      'rflib logging aura instrument --sourcepath force-app/main/default/aura --dryrun --json',
+      {
+        ensureExitCode: 0,
+        cwd: testSession.dir,
+      },
+    ).jsonOutput?.result;
+
+    expect(result?.processedFiles).to.equal(3);
+    expect(result?.modifiedFiles).to.equal(3);
+    expect(result?.formattedFiles).to.equal(0);
+  });
+
+  it('should modify aura component with logger statements', () => {
+    execCmd('rflib logging aura instrument --sourcepath force-app/main/default/aura --json', {
+      ensureExitCode: 0,
+      cwd: testSession.dir,
+    });
+
+    const cmpContent = fs.readFileSync(
+      path.join(testSession.dir, 'force-app', 'main', 'default', 'aura', 'sampleComponent', 'sampleComponent.cmp'),
+      'utf8',
+    );
+
+    const controllerContent = fs.readFileSync(
+      path.join(testSession.dir, 'force-app', 'main', 'default', 'aura', 'sampleComponent', 'sampleComponentController.js'),
+      'utf8',
+    );
+
+    const helperContent = fs.readFileSync(
+      path.join(testSession.dir, 'force-app', 'main', 'default', 'aura', 'sampleComponent', 'sampleComponentHelper.js'),
+      'utf8',
+    );
+
+    // Check component modifications
+    expect(cmpContent).to.include('<c:rflibLoggerCmp aura:id="logger" name="sampleComponent" appendComponentId="false" />');
+
+    // Check controller modifications
+    expect(controllerContent).to.include("var logger = component.find('logger')");
+    expect(controllerContent).to.include("logger.info('handleClick({0})', [event])");
+    expect(controllerContent).to.include("logger.error('An error occurred', error)");
+    expect(controllerContent).to.include("logger.info('processResult({0})', [event])");
+
+    // Check helper modifications
+    expect(helperContent).to.include("var logger = component.find('logger')");
+    expect(helperContent).to.include("logger.info('loadData({0}, {1})', [component, params])");
   });
 });

--- a/test/commands/rflib/logging/aura/instrument.nut.ts
+++ b/test/commands/rflib/logging/aura/instrument.nut.ts
@@ -1,0 +1,21 @@
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+
+describe('rflib logging aura instrument NUTs', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({ devhubAuthStrategy: 'NONE' });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  it('should display provided name', () => {
+    const name = 'World';
+    const command = `rflib logging aura instrument --name ${name}`;
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    expect(output).to.contain(name);
+  });
+});

--- a/test/commands/rflib/logging/aura/instrument.test.ts
+++ b/test/commands/rflib/logging/aura/instrument.test.ts
@@ -1,40 +1,111 @@
-import { TestContext } from '@salesforce/core/testSetup';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { expect } from 'chai';
-import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import { TestSession } from '@salesforce/cli-plugins-testkit';
 import RflibLoggingAuraInstrument from '../../../../../src/commands/rflib/logging/aura/instrument.js';
 
 describe('rflib logging aura instrument', () => {
-  const $$ = new TestContext();
-  let sfCommandStubs: ReturnType<typeof stubSfCommandUx>;
+  let testSession: TestSession;
+  let sourceDir: string;
+  let testDir: string;
+  let sampleCmpPath: string;
+  let sampleControllerPath: string;
+  let sampleHelperPath: string;
+  let modifiedContent: { [key: string]: string };
 
-  beforeEach(() => {
-    sfCommandStubs = stubSfCommandUx($$.SANDBOX);
+  before(async () => {
+    testSession = await TestSession.create();
+    sourceDir = path.join(testSession.dir, 'force-app',);
+    testDir = path.join(sourceDir, 'main', 'default', 'aura', 'sampleComponent');
+    fs.mkdirSync(testDir, { recursive: true });
+
+    const sampleCmp = `
+<aura:component>
+    <aura:attribute name="value" type="String" default="" />
+    <aura:attribute name="isValid" type="Boolean" default="false" />
+</aura:component>`;
+
+    const sampleController = `({
+    handleClick: function(component, event, helper) {
+        try {
+            helper.loadData(component);
+        } catch(error) {
+            console.error(error);
+        }
+    },
+    
+    processResult: function(component, event, helper) {
+        var data = event.getParam('data');
+        if (data.isValid) {
+            component.set("v.value", data.value);
+        }
+    }
+})`;
+
+    const sampleHelper = `({
+    loadData: function(component, params) {
+        var action = component.get("c.getData");
+        action.setParams(params);
+        action.setCallback(this, function(response) {
+            if (response.getState() === "SUCCESS") {
+                component.set("v.value", response.getReturnValue());
+            }
+        });
+        $A.enqueueAction(action);
+    }
+})`;
+
+    sampleCmpPath = path.join(testDir, 'sampleComponent.cmp');
+    sampleControllerPath = path.join(testDir, 'sampleComponentController.js');
+    sampleHelperPath = path.join(testDir, 'sampleComponentHelper.js');
+
+    fs.writeFileSync(sampleCmpPath, sampleCmp);
+    fs.writeFileSync(sampleControllerPath, sampleController);
+    fs.writeFileSync(sampleHelperPath, sampleHelper);
+
+    await RflibLoggingAuraInstrument.run(['--sourcepath', path.dirname(sourceDir)]);
+
+    modifiedContent = {
+      cmp: fs.readFileSync(sampleCmpPath, 'utf8'),
+      controller: fs.readFileSync(sampleControllerPath, 'utf8'),
+      helper: fs.readFileSync(sampleHelperPath, 'utf8')
+    };
   });
 
-  afterEach(() => {
-    $$.restore();
+  after(async () => {
+    await testSession?.clean();
   });
 
-  it('runs hello', async () => {
-    await RflibLoggingAuraInstrument.run([]);
-    const output = sfCommandStubs.log
-      .getCalls()
-      .flatMap((c) => c.args)
-      .join('\n');
-    expect(output).to.include('hello world');
+  it('should add logger component to cmp file', () => {
+    expect(modifiedContent.cmp).to.include('<c:rflibLoggerCmp aura:id="logger" name="sampleComponent" appendComponentId="false" />');
   });
 
-  it('runs hello with --json and no provided name', async () => {
-    const result = await RflibLoggingAuraInstrument.run([]);
-    expect(result.path).to.equal('src/commands/rflib/logging/aura/instrument.ts');
+  it('should add logger initialization to controller methods', () => {
+    expect(modifiedContent.controller).to.include("var logger = component.find('logger')");
+    expect(modifiedContent.controller).to.include("logger.info('handleClick({0})', [event])");
+    expect(modifiedContent.controller).to.include("logger.info('processResult({0})', [event])");
   });
 
-  it('runs hello world --name Astro', async () => {
-    await RflibLoggingAuraInstrument.run(['--name', 'Astro']);
-    const output = sfCommandStubs.log
-      .getCalls()
-      .flatMap((c) => c.args)
-      .join('\n');
-    expect(output).to.include('hello Astro');
+  it('should add logger initialization to helper methods', () => {
+    expect(modifiedContent.helper).to.include("var logger = component.find('logger')");
+    expect(modifiedContent.helper).to.include("logger.info('loadData({0}, {1})', [component, params])");
+  });
+
+  it('should add error logging to catch blocks', () => {
+    expect(modifiedContent.controller).to.include("logger.error('An error occurred', error)");
+  });
+
+  it('should process aura in dry run mode', async () => {
+    const result = await RflibLoggingAuraInstrument.run(['--sourcepath', sourceDir, '--dryrun']);
+    expect(result.processedFiles).to.be.greaterThan(0);
+    expect(result.modifiedFiles).to.be.greaterThan(0);
+    expect(result.formattedFiles).to.equal(0);
+  });
+
+  it('should format modified files when prettier flag is used', async () => {
+    await RflibLoggingAuraInstrument.run(['--sourcepath', sourceDir, '--prettier']);
+    const formattedContent = fs.readFileSync(sampleControllerPath, 'utf8');
+    expect(formattedContent).to.include(';');
+    expect(formattedContent).to.match(/\n {4}/);
   });
 });

--- a/test/commands/rflib/logging/aura/instrument.test.ts
+++ b/test/commands/rflib/logging/aura/instrument.test.ts
@@ -1,0 +1,40 @@
+import { TestContext } from '@salesforce/core/testSetup';
+import { expect } from 'chai';
+import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import RflibLoggingAuraInstrument from '../../../../../src/commands/rflib/logging/aura/instrument.js';
+
+describe('rflib logging aura instrument', () => {
+  const $$ = new TestContext();
+  let sfCommandStubs: ReturnType<typeof stubSfCommandUx>;
+
+  beforeEach(() => {
+    sfCommandStubs = stubSfCommandUx($$.SANDBOX);
+  });
+
+  afterEach(() => {
+    $$.restore();
+  });
+
+  it('runs hello', async () => {
+    await RflibLoggingAuraInstrument.run([]);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    expect(output).to.include('hello world');
+  });
+
+  it('runs hello with --json and no provided name', async () => {
+    const result = await RflibLoggingAuraInstrument.run([]);
+    expect(result.path).to.equal('src/commands/rflib/logging/aura/instrument.ts');
+  });
+
+  it('runs hello world --name Astro', async () => {
+    await RflibLoggingAuraInstrument.run(['--name', 'Astro']);
+    const output = sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+    expect(output).to.include('hello Astro');
+  });
+});

--- a/test/commands/rflib/logging/lwc/instrument.nut.ts
+++ b/test/commands/rflib/logging/lwc/instrument.nut.ts
@@ -63,13 +63,13 @@ export default class SampleComponent extends LightningElement {
 
     const modifiedContent = fs.readFileSync(
       path.join(testSession.dir, 'force-app', 'main', 'default', 'lwc', 'sampleComponent', 'sampleComponent.js'),
-      'utf8'
+      'utf8',
     );
 
     expect(modifiedContent).to.include("import { createLogger } from 'c/rflibLogger'");
     expect(modifiedContent).to.include("const logger = createLogger('SampleComponent')");
     expect(modifiedContent).to.include("logger.info('handleClick({0})', event)");
     expect(modifiedContent).to.include("logger.error('An error occurred in function handleClick()', error)");
-    expect(modifiedContent).to.include("logger.debug(`if (data.isValid)`);");
+    expect(modifiedContent).to.include('logger.debug(`if (data.isValid)`);');
   });
 });

--- a/test/commands/rflib/logging/lwc/instrument.test.ts
+++ b/test/commands/rflib/logging/lwc/instrument.test.ts
@@ -96,12 +96,12 @@ export default class SampleComponent extends LightningElement {
   });
 
   it('should handle single line promise chains', () => {
-    expect(modifiedContent).to.include(".then((response) => {\n");
-    expect(modifiedContent).to.include("return response.json()");
+    expect(modifiedContent).to.include('.then((response) => {\n');
+    expect(modifiedContent).to.include('return response.json()');
   });
 
   it('should handle template literals in promise chains', () => {
-    expect(modifiedContent).to.include("`${label} Editor`");
+    expect(modifiedContent).to.include('`${label} Editor`');
   });
 
   it('should process lwc in dry run mode', async () => {


### PR DESCRIPTION
# summary

Instrument Aura Components with RFLIB logging statements automatically.

# description

Analyzes Aura Component files and adds RFLIB logging statements for:
- Method entry logging with parameter values in Controller, Helper, and Renderer files
- Error logging in try-catch blocks
- Error logging in Promise catch handlers
- Adds rflibLoggerCmp component if not present
- Formats modified files using Prettier (optional)

The command processes:
- Component (.cmp) files to add the logger component
- Controller (.js) files for method instrumentation
- Helper (.js) files for method instrumentation
- Renderer (.js) files for method instrumentation

# flags.sourcepath.summary

Directory containing Aura components to instrument with logging.

# flags.sourcepath.description

Path to the source directory containing Aura components that should be instrumented with RFLIB logging statements. The command will:
- Scan for 'aura' directories recursively
- Process all Aura components found
- Add <c:rflibLoggerCmp> to component files
- Add logging statements to JavaScript files
- Initialize logger in methods using component.find()

# flags.dryrun.summary

Preview changes without modifying files.

# flags.dryrun.description

When enabled, shows which files would be modified without making actual changes. Useful for reviewing the impact before applying changes. Shows:
- Files that would be modified
- Number of processed files
- Number of modified files
- Number of formatted files

# flags.prettier.summary

Format modified files using Prettier.

# flags.prettier.description

When enabled, formats the modified JavaScript files using Prettier after adding logging statements. Maintains consistent code style with:
- 120 character line width
- 4 space indentation
- Single quotes for strings
- No tabs
- No trailing commas

# examples

- Add logging to all aura files:
$ sf rflib logging aura instrument --sourcepath force-app

- Preview changes:
$ sf rflib logging aura instrument --sourcepath force-app --dryrun

- Add logging and format code:
$ sf rflib logging aura instrument --sourcepath force-app --prettier

- Process specific component:
$ sf rflib logging aura instrument --sourcepath force-app/main/default/aura/myComponent