### PR TITLE
Add If-Statement Logging to Apex Code Instrumentation

### DIFF
--- a/src/commands/rflib/logging/lwc/instrument.ts
+++ b/src/commands/rflib/logging/lwc/instrument.ts
@@ -22,6 +22,11 @@ const promiseChainRegex =
   /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:\{((?:[^{}]|`[^`]*`)*?)\}|([^{;]*(?:\([^)]*\))*)(?=(?:\)\))|\)|\.))/g;
 const tryCatchBlockRegex = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
 
+type IfCondition = {
+  condition: string;
+  position: number;
+};
+
 export type RflibLoggingLwcInstrumentResult = {
   processedFiles: number;
   modifiedFiles: number;
@@ -105,31 +110,46 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
   }
 
   private static processIfStatements(content: string, loggerName: string): string {
-    let lastCondition = '';
+    const conditions: IfCondition[] = [];
 
-    // First process if statements and store conditions
-    let modified = content.replace(ifStatementRegex, (match, blockCondition, blockBody, lineCondition, lineBody) => {
-      const condition =
-        typeof blockCondition === 'string' ? blockCondition : typeof lineCondition === 'string' ? lineCondition : '';
-      lastCondition = condition.trim();
-      const logStatement = `${loggerName}.debug(\`if (${lastCondition})\`);`;
+    // Process if statements and store conditions with positions
+    let modified = content.replace(ifStatementRegex, (match: string, condition: string, blockBody: string, singleLineBody: string, offset: number) => {
+      const cleanedUpCondition = condition.trim().replaceAll("'", "\\'");
+      conditions.push({
+        condition: cleanedUpCondition,
+        position: offset
+      });
+
+      const logStatement = `${loggerName}.debug('if (${cleanedUpCondition})');\n        `;
 
       if (blockBody) {
         return `if (${condition}) {\n        ${logStatement}${blockBody}}`;
-      } else {
-        return `if (${condition}) {\n        ${logStatement}\n        ${lineBody}\n    }`;
+      } else if (singleLineBody) {
+        const cleanBody = singleLineBody.replace(/;$/, '').trim();
+        return `if (${condition}) {\n        ${logStatement}${cleanBody};\n    }`;
       }
+      return match;
     });
 
-    // Then process else blocks using stored condition
-    modified = modified.replace(elseRegex, (match, blockBody, lineBody) => {
-      const logStatement = `${loggerName}.debug(\`else for if (${lastCondition})\`);`;
+    // Process else blocks using nearest if condition
+    modified = modified.replace(elseRegex, (match, blockBody, singleLineBody, offset) => {
+      // Find last if statement before this else
+      const nearestIf = conditions
+        .filter(c => c.position < offset)
+        .reduce((prev, curr) =>
+          (!prev || curr.position > prev.position) ? curr : prev
+        );
+
+      const logStatement = nearestIf
+        ? `${loggerName}.debug('else for if (${nearestIf.condition})');\n        `
+        : `${loggerName}.debug('else statement');\n        `;
 
       if (blockBody) {
         return `} else {\n        ${logStatement}${blockBody}}`;
-      } else {
-        return `} else {\n        ${logStatement}\n        ${lineBody}\n    }`;
+      } else if (singleLineBody) {
+        return `} else {\n        ${logStatement}${singleLineBody};\n    }`;
       }
+      return match;
     });
 
     return modified;

--- a/src/commands/rflib/logging/lwc/instrument.ts
+++ b/src/commands/rflib/logging/lwc/instrument.ts
@@ -16,8 +16,8 @@ const importRegex = /import\s*{\s*createLogger\s*}\s*from\s*['"]c\/rflibLogger['
 const loggerRegex = /const\s+(\w+)\s*=\s*createLogger\s*\(['"]([\w-]+)['"]\)/;
 const methodRegex = /(?:async\s+)?(?!(?:if|switch|case|while|for|catch)\b)(\b\w+)\s*\((.*?)\)\s*{/g;
 const exportDefaultRegex = /export\s+default\s+class\s+(\w+)/;
-const ifStatementRegex = /if\s*\((.*?)\)\s*{([\s\S]*?)}|if\s*\((.*?)\)\s*([^{\n].*?)(?=\n|$)/g;
-const elseRegex = /}\s*else\s*{([\s\S]*?)}|}\s*else\s+([^{\n].*?)(?=\n|$)/g;
+const ifStatementRegex = /if\s*\((.*?)\)\s*(?:{([^]*?(?:(?<!{){(?:[^]*?)}(?!})[^]*?)*)}|([^{].*?)(?=\s*(?:;|$));)/g;
+const elseRegex = /}\s*else(?!\s+if\b)\s*(?:{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}|([^{].*?)(?=\n|;|$))/g;
 const promiseChainRegex =
   /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:\{((?:[^{}]|`[^`]*`)*?)\}|([^{;]*(?:\([^)]*\))*)(?=(?:\)\))|\)|\.))/g;
 const tryCatchBlockRegex = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
@@ -135,7 +135,7 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
     modified = modified.replace(elseRegex, (match, blockBody, singleLineBody, offset) => {
       // Find last if statement before this else
       const nearestIf = conditions
-        .filter(c => c.position < offset)
+        .filter(c => c.position <= offset)
         .reduce((prev, curr) =>
           (!prev || curr.position > prev.position) ? curr : prev
         );

--- a/test/commands/rflib/logging/apex/instrument.test.ts
+++ b/test/commands/rflib/logging/apex/instrument.test.ts
@@ -52,4 +52,22 @@ describe('rflib logging apex instrument', () => {
   it('should add error logging to catch blocks', () => {
     expect(modifiedContent).to.include("LOGGER.error('An error occurred in processRecord()', ex);");
   });
+
+  it('should add log statements to simple if blocks', () => {
+    expect(modifiedContent).to.include('LOGGER.debug(\'if (filter == null)');
+  });
+
+  it('should convert single line if statements to blocks', () => {
+    expect(modifiedContent).to.match(/if \(filter == null\) {\s+LOGGER\.debug.*\s+return new List<String>\(\);\s+}/);
+  });
+
+  it('should add log statements to if blocks with nested content', () => {
+    expect(modifiedContent).to.include('LOGGER.debug(\'if (limit > 100)');
+    expect(modifiedContent).to.match(/if \(limit > 100\) {\s+LOGGER\.debug.*\s+for \(Integer i = 0; i < 10; i\+\+\)/);
+  });
+
+  it('should add log statements to else blocks', () => {
+    expect(modifiedContent).to.include('LOGGER.debug(\'else for if (limit > 50)\')');
+    expect(modifiedContent).to.match(/else {\s+LOGGER\.debug.*\s+System.debug\('Small batch'\);\s+}/);
+  });
 });

--- a/test/commands/rflib/logging/apex/sample/SampleApexClass.cls
+++ b/test/commands/rflib/logging/apex/sample/SampleApexClass.cls
@@ -4,11 +4,19 @@ public with sharing class SampleApexClass {
     
     @AuraEnabled
     public static List<String> getRecords(String filter, Integer limit) {
-        List<String> results = new List<String>();
-        for (Integer i = 0; i < limit; i++) {
-            results.add(filter + '_' + i);
+        if (filter == null) return new List<String>();
+
+        if (limit > 100) {
+            for (Integer i = 0; i < 10; i++) {
+                System.debug('Processing...');
+            }
+        } else if (limit > 50) {
+            System.debug('Medium batch');
+        } else {
+            System.debug('Small batch');
         }
-        return results;
+
+        return new List<String>();
     }
     
     public void processRecord(SObject record, Map<Id, User> userMap) {

--- a/test/commands/rflib/logging/aura/instrument.test.ts
+++ b/test/commands/rflib/logging/aura/instrument.test.ts
@@ -95,6 +95,11 @@ describe('rflib logging aura instrument', () => {
     expect(modifiedContent.controller).to.include("logger.error('An error occurred', error)");
   });
 
+  it('should convert single line if statements to blocks', () => {
+    expect(modifiedContent.controller).to.match(/if \(data.isValid\) {\s+logger\.debug.*\s+component\.set\("v.value", data\.value\);\s+}/);
+    expect(modifiedContent.helper).to.match(/if \(response.getState\(\) === "SUCCESS"\) {\s+logger\.debug.*\s+component\.set\("v\.value", response\.getReturnValue\(\)\);\s+}/);
+  });
+
   it('should process aura in dry run mode', async () => {
     const result = await RflibLoggingAuraInstrument.run(['--sourcepath', sourceDir, '--dryrun']);
     expect(result.processedFiles).to.be.greaterThan(0);

--- a/test/commands/rflib/logging/lwc/instrument.nut.ts
+++ b/test/commands/rflib/logging/lwc/instrument.nut.ts
@@ -70,6 +70,6 @@ export default class SampleComponent extends LightningElement {
     expect(modifiedContent).to.include("const logger = createLogger('SampleComponent')");
     expect(modifiedContent).to.include("logger.info('handleClick({0})', event)");
     expect(modifiedContent).to.include("logger.error('An error occurred in function handleClick()', error)");
-    expect(modifiedContent).to.include('logger.debug(`if (data.isValid)`);');
+    expect(modifiedContent).to.include("logger.debug('if (data.isValid)');");
   });
 });

--- a/test/commands/rflib/logging/lwc/instrument.test.ts
+++ b/test/commands/rflib/logging/lwc/instrument.test.ts
@@ -21,12 +21,32 @@ describe('rflib logging lwc instrument', () => {
 import { LightningElement } from 'lwc';
 
 export default class SampleComponent extends LightningElement {
+    isEnabled = false;
+    loading = false;
+    disabled = false;
+    data = null;
+
     async handleClick(event) {
         try {
             const result = await this.loadData();
             this.processResult(result);
         } catch(error) {
             console.error(error);
+        }
+    }
+
+    handleEvent(event) {
+        if (disabled) return;
+
+        if (this.isEnabled) {
+            this.processEvent(event);
+            if (this.loading) {
+                if (this.data) {
+                    this.updateData();
+                }
+            }
+        } else {
+            this.handleError();
         }
     }
 
@@ -102,6 +122,20 @@ export default class SampleComponent extends LightningElement {
 
   it('should handle template literals in promise chains', () => {
     expect(modifiedContent).to.include('`${label} Editor`');
+  });
+
+  it('should add log statements to if blocks', () => {
+    expect(modifiedContent).to.include("logger.debug('if (this.isEnabled)");
+    expect(modifiedContent).to.match(/if \(this\.isEnabled\) {\s+logger\.debug.*\s+this\.processEvent/);
+  });
+
+  it('should convert single line if statements to blocks', () => {
+    expect(modifiedContent).to.match(/if \(disabled\) {\s+logger\.debug.*\s+return;\s+}/);
+  });
+
+  it('should add log statements to else blocks', () => {
+    expect(modifiedContent).to.include("logger.debug('else for if (this.isEnabled)");
+    expect(modifiedContent).to.match(/} else {\s+logger\.debug.*\s+this\.handleError/);
   });
 
   it('should process lwc in dry run mode', async () => {


### PR DESCRIPTION
## Description
Adds automated if/else statement logging to the Apex code instrumentation command:

- Logs if-statement conditions at debug level
- Adds corresponding else block logging referencing original condition
- Handles single line statements and nested blocks
- Supports skipping if-statement instrumentation with --no-if flag
- Preserves existing logging for methods and errors

## Changes
- Added regex patterns for if/else block detection
- Added condition tracking for else block references
- Updated tests with if/else statement coverage