### PR TITLE
Add --no-if flag to control if-else statement instrumentation

### DIFF
--- a/messages/rflib.logging.apex.instrument.md
+++ b/messages/rflib.logging.apex.instrument.md
@@ -29,7 +29,20 @@ Format modified files using Prettier.
 
 # flags.prettier.description
 
-When enabled, formats the modified Apex files using prettier-plugin-apex after adding logging statements. Maintains consistent code style.
+When enabled, formats the modified Apex files using prettier-plugin-apex after adding logging statements. Maintains consistent code style with:
+
+- 120 character line width
+- 4 space indentation
+- Single quotes for strings
+- No tabs
+
+# flags.no-if.summary
+
+Exclude the instrumentation of if-else statements.
+
+# flags.no-if.description
+
+When provided, the command will not add log statements inside of `if` and `else` blocks.
 
 # examples
 
@@ -44,3 +57,4 @@ $ sf rflib logging apex instrument --sourcepath force-app/main/default/classes -
 - Add logging statements and format code:
 
 $ sf rflib logging apex instrument --sourcepath force-app/main/default/classes --prettier
+

--- a/messages/rflib.logging.aura.instrument.md
+++ b/messages/rflib.logging.aura.instrument.md
@@ -55,6 +55,14 @@ When enabled, formats the modified JavaScript files using Prettier after adding 
 - No tabs
 - No trailing commas
 
+# flags.no-if.summary
+
+Exclude the instrumentation of if-else statements.
+
+# flags.no-if.description
+
+When provided, the command will not add log statements inside of `if` and `else` blocks.
+
 # examples
 
 - Add logging to all aura files:

--- a/messages/rflib.logging.lwc.instrument.md
+++ b/messages/rflib.logging.lwc.instrument.md
@@ -49,6 +49,14 @@ When enabled, formats the modified JavaScript files using Prettier after adding 
 - Single quotes for strings
 - No tabs
 
+# flags.no-if.summary
+
+Exclude the instrumentation of if-else statements.
+
+# flags.no-if.description
+
+When provided, the command will not add log statements inside of `if` and `else` blocks.
+
 # examples
 
 - Add logging to all LWC files:

--- a/test/commands/rflib/logging/apex/instrument.test.ts
+++ b/test/commands/rflib/logging/apex/instrument.test.ts
@@ -70,4 +70,27 @@ describe('rflib logging apex instrument', () => {
     expect(modifiedContent).to.include('LOGGER.debug(\'else for if (limit > 50)\')');
     expect(modifiedContent).to.match(/else {\s+LOGGER\.debug.*\s+System.debug\('Small batch'\);\s+}/);
   });
+
+  it('should skip if statement instrumentation when no-if flag is used', async () => {
+    // Reset the test file
+    fs.writeFileSync(sampleClassPath, originalContent);
+
+    await RflibLoggingApexInstrument.run([
+      '--sourcepath',
+      testDir,
+      '--no-if'
+    ]);
+
+    const contentWithNoIf = fs.readFileSync(sampleClassPath, 'utf8');
+
+    // Should still have method and catch logging
+    expect(contentWithNoIf).to.include("LOGGER.info('getRecords({0}, {1})'");
+    expect(contentWithNoIf).to.include("LOGGER.error('An error occurred");
+
+    // Should not have if statement logging
+    expect(contentWithNoIf).not.to.include("LOGGER.debug('if (filter == null)");
+    expect(contentWithNoIf).not.to.include("LOGGER.debug('if (limit > 100)");
+    expect(contentWithNoIf).not.to.include("LOGGER.debug('else for if");
+  });
+
 });

--- a/test/commands/rflib/logging/aura/sample/sample.cmp
+++ b/test/commands/rflib/logging/aura/sample/sample.cmp
@@ -1,0 +1,4 @@
+<aura:component>
+    <aura:attribute name="value" type="String" default="" />
+    <aura:attribute name="isValid" type="Boolean" default="false" />
+</aura:component>

--- a/test/commands/rflib/logging/aura/sample/sampleController.js
+++ b/test/commands/rflib/logging/aura/sample/sampleController.js
@@ -1,0 +1,16 @@
+({
+  handleClick: function(component, event, helper) {
+      try {
+          helper.loadData(component);
+      } catch(error) {
+          console.error(error);
+      }
+  },
+  
+  processResult: function(component, event, helper) {
+      var data = event.getParam('data');
+      if (data.isValid) {
+          component.set("v.value", data.value);
+      }
+  }
+})

--- a/test/commands/rflib/logging/aura/sample/sampleHelper.js
+++ b/test/commands/rflib/logging/aura/sample/sampleHelper.js
@@ -1,0 +1,12 @@
+({
+  loadData: function(component, params) {
+      var action = component.get("c.getData");
+      action.setParams(params);
+      action.setCallback(this, function(response) {
+          if (response.getState() === "SUCCESS") {
+              component.set("v.value", response.getReturnValue());
+          }
+      });
+      $A.enqueueAction(action);
+  }
+})

--- a/test/commands/rflib/logging/lwc/sample/sample.js
+++ b/test/commands/rflib/logging/lwc/sample/sample.js
@@ -1,0 +1,58 @@
+import { LightningElement } from 'lwc';
+
+export default class SampleComponent extends LightningElement {
+    isEnabled = false;
+    loading = false;
+    disabled = false;
+    data = null;
+
+    async handleClick(event) {
+        try {
+            const result = await this.loadData();
+            this.processResult(result);
+        } catch(error) {
+            console.error(error);
+        }
+    }
+
+    handleEvent(event) {
+        if (disabled) return;
+
+        if (this.isEnabled) {
+            this.processEvent(event);
+            if (this.loading) {
+                if (this.data) {
+                    this.updateData();
+                }
+            }
+        } else {
+            this.handleError();
+        }
+    }
+
+    loadData() {
+        return fetch('/api/data')
+            .then(response => response.json())
+            .catch(error => {
+                console.error(error);
+            });
+    }
+
+    setTitle() {
+        getCustomSettingLabel({ customSettingsApiName: this.customSettingsApiName })
+            .then((label) => {
+                this.title = `${label} Editor`;
+            })
+            .catch(error => {
+                this.title = 'Custom Settings Editor';
+            });
+    }
+
+    checkUserPermissions() {
+        return canUserModifyCustomSettings({ customSettingsApiName: this.customSettingsApiName })
+            .then(result => {
+                this.canModifySettings = result;
+            }) // checkUserPermissions must complete before the settings are loaded
+            .finally(() => this.loadCustomSettings());
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a new `--no-if` flag to the `sf rflib logging apex instrument` command that allows users to exclude instrumentation of if-else statements while still getting method entry and error logging. This provides more granular control over log verbosity.

## Changes Made

- Added new `--no-if` flag to [`RflibLoggingApexInstrument`](src/commands/rflib/logging/apex/instrument.ts)
- Updated documentation for all three instrumentation commands to include `--no-if` flag
- Updated unit tests to validate if-else instrumentation can be disabled

## Documentation Updates

Added flag documentation to:
- [messages/rflib.logging.apex.instrument.md](messages/rflib.logging.apex.instrument.md)
- [messages/rflib.logging.aura.instrument.md](messages/rflib.logging.aura.instrument.md)
- [messages/rflib.logging.lwc.instrument.md](messages/rflib.logging.lwc.instrument.md)

### Flag Details
```text
--no-if  Exclude the instrumentation of if-else statements

When provided, the command will not add log statements inside of `if` and `else` blocks.