### PR TITLE
feat: Add --skip-instrumented flag for selective logging instrumentation

### DIFF
--- a/messages/rflib.logging.apex.instrument.md
+++ b/messages/rflib.logging.apex.instrument.md
@@ -44,6 +44,15 @@ Exclude the instrumentation of if-else statements.
 
 When provided, the command will not add log statements inside of `if` and `else` blocks.
 
+
+# flags.skip-instrumented.summary
+
+Skips any files where a logger is already present.
+
+# flags.skip-instrumented.description
+
+When provided, the command will not add log statements to any Apex class that contains the `rflib_Logger` reference.
+
 # examples
 
 - Add logging statements to all Apex classes in a directory:
@@ -57,4 +66,3 @@ $ sf rflib logging apex instrument --sourcepath force-app/main/default/classes -
 - Add logging statements and format code:
 
 $ sf rflib logging apex instrument --sourcepath force-app/main/default/classes --prettier
-

--- a/messages/rflib.logging.aura.instrument.md
+++ b/messages/rflib.logging.aura.instrument.md
@@ -63,6 +63,14 @@ Exclude the instrumentation of if-else statements.
 
 When provided, the command will not add log statements inside of `if` and `else` blocks.
 
+# flags.skip-instrumented.summary
+
+Skips any files where a logger is already present.
+
+# flags.skip-instrumented.description
+
+When provided, the command will not add log statements to any Aura component that contains the `` component.
+
 # examples
 
 - Add logging to all aura files:

--- a/messages/rflib.logging.lwc.instrument.md
+++ b/messages/rflib.logging.lwc.instrument.md
@@ -57,6 +57,14 @@ Exclude the instrumentation of if-else statements.
 
 When provided, the command will not add log statements inside of `if` and `else` blocks.
 
+# flags.skip-instrumented.summary
+
+Skips any files where a logger is already present.
+
+# flags.skip-instrumented.description
+
+When provided, the command will not add log statements to any Apex class that contains the `rflib` import statement.
+
 # examples
 
 - Add logging to all LWC files:

--- a/src/commands/rflib/logging/apex/instrument.ts
+++ b/src/commands/rflib/logging/apex/instrument.ts
@@ -1,54 +1,213 @@
 /* eslint-disable no-await-in-loop */
-/* eslint-disable @typescript-eslint/quotes */
-/* eslint-disable sf-plugin/no-missing-messages */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, Logger } from '@salesforce/core';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as prettier from 'prettier';
+
+interface ApexMethodMatch {
+  auraEnabled?: string;
+  access: string;
+  isStatic?: string;
+  returnType: string;
+  methodName: string;
+  args: string;
+}
+
+interface IfCondition {
+  condition: string;
+  position: number;
+}
+
+interface InstrumentationOptions {
+  readonly prettier: boolean;
+  readonly noIf: boolean;
+  readonly skipInstrumented: boolean;
+}
+
+interface LoggerInfo {
+  readonly exists: boolean;
+  readonly variableName: string;
+}
+
+interface ProcessedParameters {
+  readonly paramList: readonly string[];
+  readonly logArgs: string;
+}
+
+export interface RflibLoggingApexInstrumentResult {
+  processedFiles: number;
+  modifiedFiles: number;
+  formattedFiles: number;
+}
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('rflib-plugin', 'rflib.logging.apex.instrument');
 
-const methodRegex =
-  /(@AuraEnabled\s*[\s\S]*?)?\b(public|private|protected|global)\s+(static\s+)?(?:(\w+(?:\s*<(?:[^<>]|<[^<>]*>)*>)?)|void)\s+(\w+)\s*\(([\s\S]*?)\)\s*{/g;
-const classRegex = /\bclass\s+\w+\s*{/;
-const classLevelLoggerRegex = /\bprivate\s+(?:static\s+)?(?:final\s+)?rflib_Logger\s+(\w+)\b/;
-const genericArgsRegex = /<[^>]+>/g;
-const catchRegex = /catch\s*\(\s*\w+\s+(\w+)\s*\)\s*{/g;
-const testSetupRegex = /@TestSetup\s+((public|private|protected|global)s+)?(?:static\s+)?void\s+(\w+)\s*\([^)]*\)\s*{/g;
-const ifStatementRegex = /if\s*\((.*?)\)\s*(?:{([^]*?(?:(?<!{){(?:[^]*?)}(?!})[^]*?)*)}|([^{].*?)(?=\s*(?:;|$));)/g;
-const elseRegex = /}\s*else(?!\s+if\b)\s*(?:{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}|([^{].*?)(?=\n|;|$))/g;
+class ApexInstrumentationService {
+  public static readonly TEST_SETUP_REGEX = /@TestSetup\s+((public|private|protected|global)s+)?(?:static\s+)?void\s+(\w+)\s*\([^)]*\)\s*{/g;
 
-const PRIMITIVE_TYPES = new Set([
-  'STRING',
-  'INTEGER',
-  'LONG',
-  'DECIMAL',
-  'DOUBLE',
-  'BOOLEAN',
-  'DATE',
-  'DATETIME',
-  'TIME',
-  'ID',
-]);
+  private static readonly METHOD_REGEX = /(@AuraEnabled\s*[\s\S]*?)?\b(public|private|protected|global)\s+(static\s+)?(?:(\w+(?:\s*<(?:[^<>]|<[^<>]*>)*>)?)|void)\s+(\w+)\s*\(([\s\S]*?)\)\s*{/g;
+  private static readonly CLASS_REGEX = /\bclass\s+\w+\s*{/;
+  private static readonly CLASS_LOGGER_REGEX = /\bprivate\s+(?:static\s+)?(?:final\s+)?rflib_Logger\s+(\w+)\b/;
+  private static readonly GENERIC_ARGS_REGEX = /<[^>]+>/g;
+  private static readonly CATCH_REGEX = /catch\s*\(\s*\w+\s+(\w+)\s*\)\s*{/g;
+  private static readonly IF_STATEMENT_REGEX = /if\s*\((.*?)\)\s*(?:{([^]*?(?:(?<!{){(?:[^]*?)}(?!})[^]*?)*)}|([^{].*?)(?=\s*(?:;|$));)/g;
+  private static readonly ELSE_REGEX = /}\s*else(?!\s+if\b)\s*(?:{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}|([^{].*?)(?=\n|;|$))/g;
+  private static readonly IS_INSTRUMENTED_REGEX = /\brflib_Logger\b/;
 
-type IfCondition = {
-  condition: string;
-  position: number;
-};
+  private static readonly PRIMITIVE_TYPES = new Set([
+    'STRING', 'INTEGER', 'LONG', 'DECIMAL', 'DOUBLE', 'BOOLEAN',
+    'DATE', 'DATETIME', 'TIME', 'ID'
+  ]);
 
-type InstrumentationFlags = {
-  prettier: boolean;
-  noIf: boolean;
-};
+  private static readonly PRETTIER_CONFIG: prettier.Options = {
+    parser: 'apex',
+    plugins: ['prettier-plugin-apex'],
+    printWidth: 120,
+    tabWidth: 4,
+    useTabs: false,
+    singleQuote: true,
+  };
 
-export type RflibLoggingApexInstrumentResult = {
-  processedFiles: number;
-  modifiedFiles: number;
-  formattedFiles: number;
-};
+  public static async formatContent(content: string): Promise<string> {
+    try {
+      return await prettier.format(content, this.PRETTIER_CONFIG);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Formatting failed: ${error.message}`);
+      }
+      throw new Error('Formatting failed with unknown error');
+    }
+  }
+
+  public static isInstrumented(content: string): boolean {
+    return this.IS_INSTRUMENTED_REGEX.test(content);
+  }
+
+  public static detectLogger(content: string): LoggerInfo {
+    const match = content.match(this.CLASS_LOGGER_REGEX);
+    return {
+      exists: this.CLASS_LOGGER_REGEX.test(content),
+      variableName: match ? match[1] : 'LOGGER'
+    };
+  }
+
+  public static addLoggerDeclaration(content: string, className: string): string {
+    const { exists, variableName } = this.detectLogger(content);
+    if (!exists) {
+      const loggerDecl = `private static final rflib_Logger ${variableName} = rflib_LoggerUtil.getFactory().createLogger('${className}');`;
+      return content.replace(this.CLASS_REGEX, `$&\n    ${loggerDecl}`);
+    }
+    return content;
+  }
+
+  public static processMethodDeclarations(content: string, loggerName: string): string {
+    return content.replace(
+      this.METHOD_REGEX,
+      (match: string, ...args: unknown[]) => {
+        const methodInfo: ApexMethodMatch = {
+          auraEnabled: args[0] as string,
+          access: args[1] as string,
+          isStatic: args[2] as string,
+          returnType: args[3] as string,
+          methodName: args[4] as string,
+          args: args[5] as string
+        };
+
+        const { paramList, logArgs } = this.processParameters(methodInfo.args);
+
+        return `${match}\n        ${loggerName}.info('${methodInfo.methodName}(${paramList.map((_, i) => `{${i}}`).join(', ')
+          })'${logArgs});\n`;
+      }
+    );
+  }
+
+  public static processCatchBlocks(content: string, loggerName: string): string {
+    return content.replace(
+      this.CATCH_REGEX,
+      (match: string, exceptionVar: string, offset: number) => {
+        const contentBeforeCatch = content.substring(0, offset);
+        const methodMatches = [...contentBeforeCatch.matchAll(this.METHOD_REGEX)];
+        const lastMethodMatch = methodMatches[methodMatches.length - 1];
+        const methodName = lastMethodMatch ? lastMethodMatch[5] : 'unknown';
+
+        return `${match}\n            ${loggerName}.error('An error occurred in ${methodName}()', ${exceptionVar.trim()});`;
+      }
+    );
+  }
+
+  public static processIfStatements(content: string, loggerName: string): string {
+    const conditions: IfCondition[] = [];
+
+    let modified = content.replace(
+      this.IF_STATEMENT_REGEX,
+      (match: string, condition: string, blockBody: string, singleLineBody: string, offset: number) => {
+        const cleanedUpCondition = condition.trim().replaceAll("'", "\\'");
+        conditions.push({
+          condition: cleanedUpCondition,
+          position: offset
+        });
+
+        const logStatement = `${loggerName}.debug('if (${cleanedUpCondition})');\n        `;
+
+        if (blockBody) {
+          return `if (${condition}) {\n        ${logStatement}${blockBody}}`;
+        } else if (singleLineBody) {
+          const cleanBody = singleLineBody.replace(/;$/, '').trim();
+          return `if (${condition}) {\n        ${logStatement}${cleanBody};\n    }`;
+        }
+        return match;
+      }
+    );
+
+    modified = modified.replace(this.ELSE_REGEX, (match: string, blockBody?: string, singleLineBody?: string, offset?: number) => {
+      const nearestIf = conditions
+        .filter((c) => c.position < (offset ?? 0))
+        .reduce((prev, curr) => (!prev || curr.position > prev.position ? curr : prev));
+
+      const logStatement = nearestIf
+        ? `${loggerName}.debug('else for if (${nearestIf.condition})');\n        `
+        : `${loggerName}.debug('else statement');\n        `;
+
+      if (blockBody) {
+        return `} else {\n        ${logStatement}${blockBody}}`;
+      } else if (singleLineBody) {
+        return `} else {\n        ${logStatement}${singleLineBody};\n    }`;
+      }
+      return match;
+    });
+
+    return modified;
+  }
+
+  private static isComplexType(paramType: string): boolean {
+    return paramType.includes('<') ||
+      paramType.includes('[') ||
+      paramType === 'Object' ||
+      !this.PRIMITIVE_TYPES.has(paramType.toUpperCase());
+  }
+
+  private static processParameters(args: string): ProcessedParameters {
+    const parameters = args
+      ? args.replaceAll(this.GENERIC_ARGS_REGEX, '')
+        .split(',')
+        .map((param) => param.trim())
+      : [];
+
+    const logArgs = parameters.length > 0 && parameters[0] !== ''
+      ? `, new Object[] { ${parameters
+        .map((p) => {
+          const [paramType, ...rest] = p.split(' ');
+          const paramName = rest.length > 0 ? rest.join(' ') : paramType;
+          return this.isComplexType(paramType) ? `JSON.serialize(${paramName})` : paramName;
+        })
+        .join(', ')} }`
+      : '';
+
+    return { paramList: parameters, logArgs };
+  }
+}
 
 export default class RflibLoggingApexInstrument extends SfCommand<RflibLoggingApexInstrumentResult> {
   public static readonly summary = messages.getMessage('summary');
@@ -76,160 +235,22 @@ export default class RflibLoggingApexInstrument extends SfCommand<RflibLoggingAp
     }),
     'no-if': Flags.boolean({
       summary: messages.getMessage('flags.no-if.summary'),
+      description: messages.getMessage('flags.no-if.description'),
+      default: false,
+    }),
+    'skip-instrumented': Flags.boolean({
+      summary: messages.getMessage('flags.skip-instrumented.summary'),
+      description: messages.getMessage('flags.skip-instrumented.description'),
+      default: false,
     }),
   };
 
   private logger!: Logger;
-
-  private processedFiles = 0;
-  private modifiedFiles = 0;
-  private formattedFiles = 0;
-
-  private readonly prettierConfig: prettier.Options = {
-    parser: 'apex',
-    plugins: ['prettier-plugin-apex'],
-    printWidth: 120,
-    tabWidth: 4,
-    useTabs: false,
-    singleQuote: true,
+  private readonly stats: RflibLoggingApexInstrumentResult = {
+    processedFiles: 0,
+    modifiedFiles: 0,
+    formattedFiles: 0
   };
-
-  private static isComplexType(paramType: string): boolean {
-    return (
-      paramType.includes('<') ||
-      paramType.includes('[') ||
-      paramType === 'Object' ||
-      !PRIMITIVE_TYPES.has(paramType.toUpperCase())
-    );
-  }
-
-  private static detectExistingLogger(content: string): { exists: boolean; loggerVariableName: string } {
-    const match = content.match(classLevelLoggerRegex);
-    return {
-      exists: classLevelLoggerRegex.test(content),
-      loggerVariableName: match ? match[1] : 'LOGGER',
-    };
-  }
-
-  private static addLoggerDeclaration(content: string, className: string): string {
-    const { exists, loggerVariableName } = RflibLoggingApexInstrument.detectExistingLogger(content);
-    if (!exists) {
-      const loggerDeclaration = `private static final rflib_Logger ${loggerVariableName} = rflib_LoggerUtil.getFactory().createLogger('${className}');`;
-      return content.replace(classRegex, `$&\n    ${loggerDeclaration}`);
-    }
-    return content;
-  }
-
-  private static processParameters(args: string): { paramList: string[]; logArgs: string } {
-    const parameters = args
-      ? args
-        .replaceAll(genericArgsRegex, '')
-        .split(',')
-        .map((param) => param.trim())
-      : [];
-
-    const logArgs =
-      parameters.length > 0 && parameters[0] !== ''
-        ? `, new Object[] { ${parameters
-          .map((p) => {
-            const parts = p.split(' ');
-            const paramType = parts[0];
-            const paramName = parts.length > 1 ? parts[1] : parts[0];
-
-            return this.isComplexType(paramType) ? `JSON.serialize(${paramName})` : paramName;
-          })
-          .join(', ')} }`
-        : '';
-
-    return { paramList: parameters, logArgs };
-  }
-
-  private static processMethodDeclarations(content: string, loggerName: string): string {
-    return content.replace(
-      methodRegex,
-      (
-        match: string,
-        auraEnabled: string | undefined,
-        access: string,
-        isStatic: string | undefined,
-        returnType: string,
-        methodName: string,
-        args: string,
-      ) => {
-        const { paramList, logArgs } = RflibLoggingApexInstrument.processParameters(args);
-        let newMethod = match + '\n';
-        newMethod += `        ${loggerName}.info('${methodName}(${paramList.map((_, i) => `{${i}}`).join(', ')})'${logArgs});\n`;
-        return newMethod;
-      },
-    );
-  }
-
-  private static processCatchBlocks(content: string, loggerName: string): string {
-    return content.replace(catchRegex, (match: string, exceptionVar: string, offset: number) => {
-      // Get content before catch block
-      const contentBeforeCatch = content.substring(0, offset);
-
-      // Find all method declarations before this catch block
-      const methodMatches = [...contentBeforeCatch.matchAll(methodRegex)];
-
-      // Get last method match (closest to catch block)
-      const lastMethodMatch = methodMatches[methodMatches.length - 1];
-
-      // Extract method name from match or use 'unknown'
-      const methodName = lastMethodMatch
-        ? lastMethodMatch[5] // Group 4 contains method name in methodRegex
-        : 'unknown';
-
-      return `${match}\n            ${loggerName}.error('An error occurred in ${methodName}()', ${exceptionVar.trim()});`;
-    });
-  }
-
-  private static processIfStatements(content: string, loggerName: string): string {
-    const conditions: IfCondition[] = [];
-
-    // Process if statements and store conditions with positions
-    let modified = content.replace(
-      ifStatementRegex,
-      (match: string, condition: string, blockBody: string, singleLineBody: string, offset: number) => {
-        const cleanedUpCondition = condition.trim().replaceAll("'", "\\'");
-        conditions.push({
-          condition: cleanedUpCondition,
-          position: offset,
-        });
-
-        const logStatement = `${loggerName}.debug('if (${cleanedUpCondition})');\n        `;
-
-        if (blockBody) {
-          return `if (${condition}) {\n        ${logStatement}${blockBody}}`;
-        } else if (singleLineBody) {
-          const cleanBody = singleLineBody.replace(/;$/, '').trim();
-          return `if (${condition}) {\n        ${logStatement}${cleanBody};\n    }`;
-        }
-        return match;
-      },
-    );
-
-    // Process else blocks using nearest if condition
-    modified = modified.replace(elseRegex, (match, blockBody, singleLineBody, offset) => {
-      // Find last if statement before this else
-      const nearestIf = conditions
-        .filter((c) => c.position < offset)
-        .reduce((prev, curr) => (!prev || curr.position > prev.position ? curr : prev));
-
-      const logStatement = nearestIf
-        ? `${loggerName}.debug('else for if (${nearestIf.condition})');\n        `
-        : `${loggerName}.debug('else statement');\n        `;
-
-      if (blockBody) {
-        return `} else {\n        ${logStatement}${blockBody}}`;
-      } else if (singleLineBody) {
-        return `} else {\n        ${logStatement}${singleLineBody};\n    }`;
-      }
-      return match;
-    });
-
-    return modified;
-  }
 
   public async run(): Promise<RflibLoggingApexInstrumentResult> {
     this.logger = await Logger.child(this.ctor.name);
@@ -239,34 +260,35 @@ export default class RflibLoggingApexInstrument extends SfCommand<RflibLoggingAp
     const sourcePath = flags.sourcepath;
     const isDryRun = flags.dryrun;
 
-    const instrumentationFlags = {
+    const instrumentationOpts: InstrumentationOptions = {
       prettier: flags.prettier,
       noIf: flags['no-if'],
+      skipInstrumented: flags['skip-instrumented']
     };
 
     this.log(`Scanning Apex classes in ${sourcePath} and sub directories`);
-    this.logger.debug(`Dry run mode: ${flags.dryrun}`);
+    this.logger.debug(`Dry run mode: ${isDryRun}`);
 
     this.spinner.start('Running...');
-    await this.processDirectory(sourcePath, isDryRun, instrumentationFlags);
+    await this.processDirectory(sourcePath, isDryRun, instrumentationOpts);
     this.spinner.stop();
 
     const duration = Date.now() - startTime;
     this.logger.debug(`Completed instrumentation in ${duration}ms`);
 
-    this.log(`\nInstrumentation complete.`);
-    this.log(`Processed files: ${this.processedFiles}`);
-    this.log(`Modified files: ${this.modifiedFiles}`);
-    this.log(`Formatted files: ${this.formattedFiles}`);
+    this.log('\nInstrumentation complete.');
+    this.log(`Processed files: ${this.stats.processedFiles}`);
+    this.log(`Modified files: ${this.stats.modifiedFiles}`);
+    this.log(`Formatted files: ${this.stats.formattedFiles}`);
 
-    return {
-      processedFiles: this.processedFiles,
-      modifiedFiles: this.modifiedFiles,
-      formattedFiles: this.formattedFiles,
-    };
+    return { ...this.stats };
   }
 
-  private async processDirectory(dirPath: string, isDryRun: boolean, flags: InstrumentationFlags): Promise<void> {
+  private async processDirectory(
+    dirPath: string,
+    isDryRun: boolean,
+    instrumentationOpts: InstrumentationOptions
+  ): Promise<void> {
     this.logger.debug(`Processing directory: ${dirPath}`);
     const files = await fs.promises.readdir(dirPath);
 
@@ -275,11 +297,11 @@ export default class RflibLoggingApexInstrument extends SfCommand<RflibLoggingAp
       const stat = await fs.promises.stat(filePath);
 
       if (stat.isDirectory()) {
-        await this.processDirectory(filePath, isDryRun, flags);
+        await this.processDirectory(filePath, isDryRun, instrumentationOpts);
       } else if (file.endsWith('Test.cls')) {
         await this.processTestFile(filePath, isDryRun);
       } else if (file.endsWith('.cls')) {
-        await this.instrumentApexClass(filePath, isDryRun, flags);
+        await this.instrumentApexClass(filePath, isDryRun, instrumentationOpts);
       }
     }
   }
@@ -290,12 +312,12 @@ export default class RflibLoggingApexInstrument extends SfCommand<RflibLoggingAp
     const originalContent = content;
 
     content = content.replace(
-      testSetupRegex,
-      (match) => `${match}\n        rflib_TestUtil.prepareLoggerForUnitTests();`,
+      ApexInstrumentationService.TEST_SETUP_REGEX,
+      (match) => `${match}\n        rflib_TestUtil.prepareLoggerForUnitTests();`
     );
 
     if (content !== originalContent) {
-      this.modifiedFiles++;
+      this.stats.modifiedFiles++;
       if (!isDryRun) {
         await fs.promises.writeFile(filePath, content);
         this.logger.info(`Modified test file: ${filePath}`);
@@ -305,45 +327,51 @@ export default class RflibLoggingApexInstrument extends SfCommand<RflibLoggingAp
     }
   }
 
-  private async instrumentApexClass(filePath: string, isDryRun: boolean, flags: InstrumentationFlags): Promise<void> {
-    const usePrettier = flags.prettier;
-
+  private async instrumentApexClass(
+    filePath: string,
+    isDryRun: boolean,
+    instrumentationOpts: InstrumentationOptions
+  ): Promise<void> {
     const className = path.basename(filePath, '.cls');
     this.logger.debug(`Processing class: ${className}`);
 
     try {
-      this.processedFiles++;
+      this.stats.processedFiles++;
       let content = await fs.promises.readFile(filePath, 'utf8');
       const originalContent = content;
 
-      const { loggerVariableName } = RflibLoggingApexInstrument.detectExistingLogger(content);
-      content = RflibLoggingApexInstrument.addLoggerDeclaration(content, className);
-      content = RflibLoggingApexInstrument.processMethodDeclarations(content, loggerVariableName);
-      content = RflibLoggingApexInstrument.processCatchBlocks(content, loggerVariableName);
-      if (!flags.noIf) {
-        content = RflibLoggingApexInstrument.processIfStatements(content, loggerVariableName);
+      if (instrumentationOpts.skipInstrumented && ApexInstrumentationService.isInstrumented(content)) {
+        this.logger.info(`Skipping instrumented class: ${className}`);
+        return;
+      }
+
+      const { variableName } = ApexInstrumentationService.detectLogger(content);
+      content = ApexInstrumentationService.addLoggerDeclaration(content, className);
+      content = ApexInstrumentationService.processMethodDeclarations(content, variableName);
+      content = ApexInstrumentationService.processCatchBlocks(content, variableName);
+
+      if (!instrumentationOpts.noIf) {
+        content = ApexInstrumentationService.processIfStatements(content, variableName);
       }
 
       if (content !== originalContent) {
-        this.modifiedFiles++;
+        this.stats.modifiedFiles++;
         if (!isDryRun) {
           try {
-            const finalContent = usePrettier ? await prettier.format(content, this.prettierConfig) : content;
+            const finalContent = instrumentationOpts.prettier
+              ? await ApexInstrumentationService.formatContent(content)
+              : content;
 
             await fs.promises.writeFile(filePath, finalContent);
 
-            if (usePrettier) {
-              this.formattedFiles++;
+            if (instrumentationOpts.prettier) {
+              this.stats.formattedFiles++;
               this.logger.info(`Modified and formatted: ${filePath}`);
             } else {
               this.logger.info(`Modified: ${filePath}`);
             }
           } catch (error) {
-            if (error instanceof Error) {
-              this.logger.warn(`Failed to format ${filePath}: ${error.message}`);
-            } else {
-              this.logger.warn(`Failed to format ${filePath}: ${String(error)}`);
-            }
+            this.logger.warn(`Failed to format ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
             await fs.promises.writeFile(filePath, content);
             this.logger.info(`Modified without formatting: ${filePath}`);
           }

--- a/src/commands/rflib/logging/aura/instrument.ts
+++ b/src/commands/rflib/logging/aura/instrument.ts
@@ -1,45 +1,210 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 /* eslint-disable no-await-in-loop */
-/* eslint-disable @typescript-eslint/quotes */
-/* eslint-disable sf-plugin/no-missing-messages */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, Logger } from '@salesforce/core';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as prettier from 'prettier';
+
+interface IfCondition {
+  readonly condition: string;
+  readonly position: number;
+}
+
+interface InstrumentationOptions {
+  readonly prettier: boolean;
+  readonly noIf: boolean;
+  readonly skipInstrumented: boolean;
+}
+
+interface ProcessedPromise {
+  readonly logStatement: string;
+  readonly paramName: string;
+}
+
+export interface RflibLoggingAuraInstrumentResult {
+  processedFiles: number;
+  modifiedFiles: number;
+  formattedFiles: number;
+}
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('rflib-plugin', 'rflib.logging.aura.instrument');
 
-const loggerComponentRegex =
-  /<c:rflibLoggerCmp\s+aura:id="([^"]+)"\s+name="([^"]+)"\s+appendComponentId="([^"]+)"\s*\/>/;
-const attributeRegex = /<aura:attribute[^>]*>/g;
-const loggerVarRegex = /var\s+(\w+)\s*=\s*\w+\.find\(['"](\w+)['"]\)/;
-const methodRegex =
-  /(\b\w+)\s*:\s*function\s*\((.*?)\)\s*{((?:[^{}]|{(?:[^{}]|{(?:[^{}]|{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})*})*})*?)}/g;
-const promiseChainRegex =
-  /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:{([\s\S]*?)}|([^{].*?)(?=\.|\)|\n|;|$))/g;
-const tryCatchBlockRegex = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
-const ifStatementRegex = /if\s*\((.*?)\)\s*(?:{([^]*?(?:(?<!{){(?:[^]*?)}(?!})[^]*?)*)}|([^{].*?)(?=\s*(?:;|$));)/g;
-const elseRegex = /}\s*else(?!\s+if\b)\s*(?:{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}|([^{].*?)(?=\n|;|$))/g;
+class AuraInstrumentationService {
+  public static readonly ATTRIBUTE_REGEX = /<aura:attribute[^>]*>/g;
+  public static readonly LOGGER_COMPONENT_REGEX = /<c:rflibLoggerCmp\s+aura:id="([^"]+)"\s+name="([^"]+)"\s+appendComponentId="([^"]+)"\s*\/>/;
 
-type IfCondition = {
-  condition: string;
-  position: number;
-};
+  private static readonly LOGGER_VAR_REGEX = /var\s+(\w+)\s*=\s*\w+\.find\(['"](\w+)['"]\)/;
+  private static readonly METHOD_REGEX = /(\b\w+)\s*:\s*function\s*\((.*?)\)\s*{((?:[^{}]|{(?:[^{}]|{(?:[^{}]|{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*})*})*})*?)}/g;
+  private static readonly PROMISE_CHAIN_REGEX = /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:{([\s\S]*?)}|([^{].*?)(?=\.|\)|\n|;|$))/g;
+  private static readonly TRY_CATCH_BLOCK_REGEX = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
+  private static readonly IF_STATEMENT_REGEX = /if\s*\((.*?)\)\s*(?:{([^]*?(?:(?<!{){(?:[^]*?)}(?!})[^]*?)*)}|([^{].*?)(?=\s*(?:;|$));)/g;
+  private static readonly ELSE_REGEX = /}\s*else(?!\s+if\b)\s*(?:{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}|([^{].*?)(?=\n|;|$))/g;
 
-type InstrumentationFlags = {
-  prettier: boolean;
-  noIf: boolean;
-  skipInstrumented: boolean;
-};
+  private static readonly PRETTIER_CONFIG: prettier.Options = {
+    parser: 'babel',
+    printWidth: 120,
+    tabWidth: 4,
+    useTabs: false,
+    singleQuote: true,
+    trailingComma: 'none'
+  };
 
-export type RflibLoggingAuraInstrumentResult = {
-  processedFiles: number;
-  modifiedFiles: number;
-  formattedFiles: number;
-};
+  public static isInstrumented(content: string, loggerId: string): boolean {
+    return new RegExp(`\\.find\\(['"]${loggerId}['"]\\)`, 'g').test(content);
+  }
+
+  public static async formatContent(content: string): Promise<string> {
+    try {
+      return await prettier.format(content, this.PRETTIER_CONFIG);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Formatting failed: ${error.message}`);
+      }
+      throw new Error('Formatting failed with unknown error');
+    }
+  }
+
+  public static processMethodLogging(
+    content: string,
+    loggerId: string,
+    isHelper: boolean,
+    noIf: boolean
+  ): string {
+    return content.replace(
+      this.METHOD_REGEX,
+      (match: string, methodName: string, params: string, body: string) => {
+        const paramList = params.split(',').map((p) => p.trim()).filter(Boolean);
+        let loggerVar = 'logger';
+        let bodyContent = body;
+
+        const paramsToLog = isHelper ? paramList : paramList.slice(1, 2);
+        const placeholders = paramsToLog.map((_, i) => `{${i}}`).join(', ');
+        const logParams = paramsToLog.length > 0 ? `, [${paramsToLog.join(', ')}]` : '';
+
+        const loggerMatch = body.match(this.LOGGER_VAR_REGEX);
+        if (loggerMatch && loggerMatch[2] === loggerId) {
+          loggerVar = loggerMatch[1];
+          const loggerIndex = body.indexOf(loggerMatch[0]) + loggerMatch[0].length;
+          bodyContent = `${body.slice(0, loggerIndex)}\n        ${loggerVar}.info('${methodName}(${placeholders})'${logParams});${body.slice(loggerIndex)}`;
+        } else {
+          const loggerInit = `var ${loggerVar} = ${paramList[0]}.find('${loggerId}');\n`;
+          bodyContent = `\n        ${loggerInit}        ${loggerVar}.info('${methodName}(${placeholders})'${logParams});${body}`;
+        }
+
+        if (!noIf) {
+          bodyContent = this.processIfStatements(bodyContent, loggerVar);
+        }
+
+        return `${methodName}: function(${params}) {${bodyContent}}`;
+      }
+    );
+  }
+
+  public static processPromiseChains(content: string): string {
+    return content.replace(
+      this.PROMISE_CHAIN_REGEX,
+      (match: string, type: string, param: string, blockBody?: string, singleLineBody?: string) => {
+        const { logStatement, paramName } = this.processPromiseType(type, param?.trim() || '');
+
+        if (singleLineBody) {
+          return `.${type}(${paramName ? paramName : ''} => {
+            ${logStatement}
+            return ${singleLineBody};
+          })`;
+        }
+
+        if (blockBody) {
+          return `.${type}(${paramName ? paramName : ''} => {
+            ${logStatement}${blockBody}
+          })`;
+        }
+
+        return match;
+      }
+    );
+  }
+
+  public static processTryCatchBlocks(content: string): string {
+    return content.replace(
+      this.TRY_CATCH_BLOCK_REGEX,
+      (match: string, exceptionVar: string) => {
+        const errorVar = exceptionVar.trim().split(' ')[0] || 'error';
+        return match.replace(
+          /catch\s*\(([^)]*)\)\s*{/,
+          `catch(${exceptionVar}) {
+            logger.error('An error occurred', ${errorVar});`
+        );
+      }
+    );
+  }
+
+  private static processPromiseType(type: string, paramName: string): ProcessedPromise {
+    switch (type) {
+      case 'then':
+        return {
+          logStatement: `logger.info('Promise resolved. Result={0}', ${paramName});`,
+          paramName: paramName || 'result'
+        };
+      case 'catch':
+        return {
+          logStatement: `logger.error('An error occurred', ${paramName});`,
+          paramName: paramName || 'error'
+        };
+      case 'finally':
+        return {
+          logStatement: 'logger.info(\'Promise chain completed\');',
+          paramName: paramName || ''
+        };
+      default:
+        throw new Error(`Unsupported promise type: ${type}`);
+    }
+  }
+
+  private static processIfStatements(content: string, loggerName: string): string {
+    const conditions: IfCondition[] = [];
+
+    let modified = content.replace(
+      this.IF_STATEMENT_REGEX,
+      (match: string, condition: string, blockBody: string, singleLineBody: string, offset: number) => {
+        const cleanedUpCondition = condition.trim().replaceAll("'", "\\'");
+        conditions.push({ condition: cleanedUpCondition, position: offset });
+
+        const logStatement = `${loggerName}.debug('if (${cleanedUpCondition})');\n        `;
+
+        if (blockBody) {
+          return `if (${condition}) {\n        ${logStatement}${blockBody}}`;
+        } else if (singleLineBody) {
+          const cleanBody = singleLineBody.replace(/;$/, '').trim();
+          return `if (${condition}) {\n        ${logStatement}${cleanBody};\n    }`;
+        }
+        return match;
+      }
+    );
+
+    modified = modified.replace(
+      this.ELSE_REGEX,
+      (match: string, blockBody: string, singleLineBody: string, offset: number) => {
+        const nearestIf = conditions
+          .filter((c) => c.position < offset)
+          .reduce((prev, curr) => (!prev || curr.position > prev.position ? curr : prev));
+
+        const logStatement = nearestIf
+          ? `${loggerName}.debug('else for if (${nearestIf.condition})');\n        `
+          : `${loggerName}.debug('else statement');\n        `;
+
+        if (blockBody) {
+          return `} else {\n        ${logStatement}${blockBody}}`;
+        } else if (singleLineBody) {
+          return `} else {\n        ${logStatement}${singleLineBody};\n    }`;
+        }
+        return match;
+      }
+    );
+
+    return modified;
+  }
+}
 
 export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAuraInstrumentResult> {
   public static readonly summary = messages.getMessage('summary');
@@ -51,230 +216,77 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
       char: 's',
       required: true,
       summary: messages.getMessage('flags.sourcepath.summary'),
-      description: messages.getMessage('flags.sourcepath.description'),
+      description: messages.getMessage('flags.sourcepath.description')
     }),
     dryrun: Flags.boolean({
       char: 'd',
       default: false,
       summary: messages.getMessage('flags.dryrun.summary'),
-      description: messages.getMessage('flags.dryrun.description'),
+      description: messages.getMessage('flags.dryrun.description')
     }),
     prettier: Flags.boolean({
       char: 'p',
       default: false,
       summary: messages.getMessage('flags.prettier.summary'),
-      description: messages.getMessage('flags.prettier.description'),
+      description: messages.getMessage('flags.prettier.description')
     }),
     'no-if': Flags.boolean({
       summary: messages.getMessage('flags.no-if.summary'),
       description: messages.getMessage('flags.no-if.description'),
-      default: false,
+      default: false
     }),
     'skip-instrumented': Flags.boolean({
       summary: messages.getMessage('flags.skip-instrumented.summary'),
       description: messages.getMessage('flags.skip-instrumented.description'),
-      default: false,
-    }),
+      default: false
+    })
   };
 
   private logger!: Logger;
-  private processedFiles = 0;
-  private modifiedFiles = 0;
-  private formattedFiles = 0;
-
-  private readonly prettierConfig: prettier.Options = {
-    parser: 'babel',
-    printWidth: 120,
-    tabWidth: 4,
-    useTabs: false,
-    singleQuote: true,
-    trailingComma: 'none',
+  private readonly stats: RflibLoggingAuraInstrumentResult = {
+    processedFiles: 0,
+    modifiedFiles: 0,
+    formattedFiles: 0
   };
-
-  private static processMethodLogging(
-    logger: Logger,
-    content: string,
-    loggerId: string,
-    filePath: string,
-    flags: InstrumentationFlags,
-  ): string {
-    const isHelper = filePath.endsWith('Helper.js');
-
-    return content.replace(methodRegex, (match: string, methodName: string, params: string, body: string) => {
-      logger.trace(`Processing method: ${methodName}`);
-
-      const paramList = params
-        .split(',')
-        .map((p) => p.trim())
-        .filter((p) => p);
-      let loggerVar = 'logger';
-      let bodyContent = body;
-
-      // Prepare logging parameters
-      const paramsToLog = isHelper ? paramList : paramList.slice(1, 2);
-      const placeholders = paramsToLog.map((_, i) => `{${i}}`).join(', ');
-      const logParams = paramsToLog.length > 0 ? `, [${paramsToLog.join(', ')}]` : '';
-
-      // Find existing logger in function body
-      const loggerMatch = body.match(loggerVarRegex);
-      if (loggerMatch && loggerMatch[2] === loggerId) {
-        loggerVar = loggerMatch[1];
-        // Insert log after existing logger declaration
-        const loggerIndex = body.indexOf(loggerMatch[0]) + loggerMatch[0].length;
-        bodyContent =
-          body.slice(0, loggerIndex) +
-          `\n        ${loggerVar}.info('${methodName}(${placeholders})'${logParams});` +
-          body.slice(loggerIndex);
-      } else {
-        // Add new logger and log statement
-        const loggerInit = `var ${loggerVar} = ${paramList[0]}.find('${loggerId}');\n`;
-        bodyContent = `\n        ${loggerInit}        ${loggerVar}.info('${methodName}(${placeholders})'${logParams});${body}`;
-      }
-
-      // Then handle if statements
-      if (!flags.noIf) {
-        bodyContent = this.processIfStatements(bodyContent, loggerVar);
-      }
-
-      return `${methodName}: function(${params}) {${bodyContent}}`;
-    });
-  }
-
-  private static processPromiseChains(content: string): string {
-    return content.replace(promiseChainRegex, (match, type, param, blockBody, singleLineBody) => {
-      const paramName = (param as string | undefined)?.trim() || (type === 'then' ? 'result' : 'error');
-
-      let logStatement = '';
-      switch (type) {
-        case 'then':
-          logStatement = `logger.info('Promise resolved. Result={0}', ${paramName});`;
-          break;
-        case 'catch':
-          logStatement = `logger.error('An error occurred', ${paramName});`;
-          break;
-        case 'finally':
-          logStatement = `logger.info('Promise chain completed');`;
-          break;
-      }
-
-      if (singleLineBody) {
-        return `.${type}(${param || paramName} => {
-          ${logStatement}
-          return ${singleLineBody};
-        })`;
-      }
-
-      if (blockBody) {
-        return `.${type}(${param || paramName} => {
-          ${logStatement}${blockBody}
-        })`;
-      }
-
-      return match;
-    });
-  }
-
-  private static processTryCatchBlocks(content: string): string {
-    return content.replace(tryCatchBlockRegex, (match: string, exceptionVar: string) => {
-      const errorVar = exceptionVar.trim().split(' ')[0] || 'error';
-
-      return match.replace(
-        /catch\s*\(([^)]*)\)\s*{/,
-        `catch(${exceptionVar}) {
-          logger.error('An error occurred', ${errorVar});`,
-      );
-    });
-  }
-
-  private static processIfStatements(content: string, loggerName: string): string {
-    const conditions: IfCondition[] = [];
-
-    // Process if statements and store conditions with positions
-    let modified = content.replace(
-      ifStatementRegex,
-      (match: string, condition: string, blockBody: string, singleLineBody: string, offset: number) => {
-        const cleanedUpCondition = condition.trim().replaceAll("'", "\\'");
-        conditions.push({
-          condition: cleanedUpCondition,
-          position: offset,
-        });
-
-        const logStatement = `${loggerName}.debug('if (${cleanedUpCondition})');\n        `;
-
-        if (blockBody) {
-          return `if (${condition}) {\n        ${logStatement}${blockBody}}`;
-        } else if (singleLineBody) {
-          const cleanBody = singleLineBody.replace(/;$/, '').trim();
-          return `if (${condition}) {\n        ${logStatement}${cleanBody};\n    }`;
-        }
-        return match;
-      },
-    );
-
-    // Process else blocks using nearest if condition
-    modified = modified.replace(elseRegex, (match, blockBody, singleLineBody, offset) => {
-      // Find last if statement before this else
-      const nearestIf = conditions
-        .filter((c) => c.position < offset)
-        .reduce((prev, curr) => (!prev || curr.position > prev.position ? curr : prev));
-
-      const logStatement = nearestIf
-        ? `${loggerName}.debug('else for if (${nearestIf.condition})');\n        `
-        : `${loggerName}.debug('else statement');\n        `;
-
-      if (blockBody) {
-        return `} else {\n        ${logStatement}${blockBody}}`;
-      } else if (singleLineBody) {
-        return `} else {\n        ${logStatement}${singleLineBody};\n    }`;
-      }
-      return match;
-    });
-
-    return modified;
-  }
-
-  private static isInstrumented(content: string, loggerId: string): boolean {
-    return new RegExp(`\\.find\\(['"]${loggerId}['"]\\)`, 'g').test(content);
-  }
 
   public async run(): Promise<RflibLoggingAuraInstrumentResult> {
     this.logger = await Logger.child(this.ctor.name);
     const { flags } = await this.parse(RflibLoggingAuraInstrument);
 
-    const instrumentationFlags = {
+    const instrumentationOpts: InstrumentationOptions = {
       prettier: flags.prettier,
       noIf: flags['no-if'],
-      skipInstrumented: flags['skip-instrumented'],
+      skipInstrumented: flags['skip-instrumented']
     };
 
     this.log(`Starting Aura component instrumentation in ${flags.sourcepath}`);
     this.logger.debug(`Dry run mode: ${flags.dryrun}`);
 
     this.spinner.start('Running...');
-    await this.processDirectory(flags.sourcepath, flags.dryrun, instrumentationFlags);
+    await this.processDirectory(flags.sourcepath, flags.dryrun, instrumentationOpts);
     this.spinner.stop();
 
-    this.log(`\nInstrumentation complete.`);
-    this.log(`Processed files: ${this.processedFiles}`);
-    this.log(`Modified files: ${this.modifiedFiles}`);
-    this.log(`Formatted files: ${this.formattedFiles}`);
+    this.log('\nInstrumentation complete.');
+    this.log(`Processed files: ${this.stats.processedFiles}`);
+    this.log(`Modified files: ${this.stats.modifiedFiles}`);
+    this.log(`Formatted files: ${this.stats.formattedFiles}`);
 
-    return {
-      processedFiles: this.processedFiles,
-      modifiedFiles: this.modifiedFiles,
-      formattedFiles: this.formattedFiles,
-    };
+    return { ...this.stats };
   }
 
-  private async processDirectory(dirPath: string, isDryRun: boolean, flags: InstrumentationFlags): Promise<void> {
+  private async processDirectory(
+    dirPath: string,
+    isDryRun: boolean,
+    instrumentationOpts: InstrumentationOptions
+  ): Promise<void> {
     this.logger.debug(`Processing directory: ${dirPath}`);
 
-    // Check if path is direct component
     const dirName = path.basename(dirPath);
     const parentDir = path.basename(path.dirname(dirPath));
+
     if (parentDir === 'aura') {
       this.logger.info(`Processing single component: ${dirName}`);
-      await this.processAuraComponent(dirPath, dirName, isDryRun, flags);
+      await this.processAuraComponent(dirPath, dirName, isDryRun, instrumentationOpts);
       return;
     }
 
@@ -282,21 +294,22 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
 
     for (const entry of entries) {
       const fullPath = path.join(dirPath, entry.name);
-      this.logger.debug(`Examining entry: ${entry.name}`);
 
       if (entry.isDirectory()) {
         if (entry.name === 'aura') {
-          this.logger.info(`Found Aura directory: ${fullPath}`);
-          await this.processAuraComponents(fullPath, isDryRun, flags);
+          await this.processAuraComponents(fullPath, isDryRun, instrumentationOpts);
         } else {
-          await this.processDirectory(fullPath, isDryRun, flags);
+          await this.processDirectory(fullPath, isDryRun, instrumentationOpts);
         }
       }
     }
   }
 
-  private async processAuraComponents(auraPath: string, isDryRun: boolean, flags: InstrumentationFlags): Promise<void> {
-    // Check if path is already an aura directory
+  private async processAuraComponents(
+    auraPath: string,
+    isDryRun: boolean,
+    instrumentationOpts: InstrumentationOptions
+  ): Promise<void> {
     if (path.basename(auraPath) !== 'aura') {
       this.logger.warn(`Not an aura directory: ${auraPath}`);
       return;
@@ -307,7 +320,7 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
     for (const entry of entries) {
       if (entry.isDirectory()) {
         const componentPath = path.join(auraPath, entry.name);
-        await this.processAuraComponent(componentPath, entry.name, isDryRun, flags);
+        await this.processAuraComponent(componentPath, entry.name, isDryRun, instrumentationOpts);
       }
     }
   }
@@ -316,7 +329,7 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
     componentPath: string,
     componentName: string,
     isDryRun: boolean,
-    flags: InstrumentationFlags,
+    instrumentationOpts: InstrumentationOptions
   ): Promise<void> {
     this.logger.info(`Processing Aura component: ${componentName}`);
 
@@ -329,31 +342,37 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
       const loggerId = await this.instrumentCmpFile(cmpPath, componentName, isDryRun);
       this.logger.debug(`Using logger ID: ${loggerId}`);
 
-      await this.instrumentJsFile(controllerPath, loggerId, isDryRun, flags);
-      await this.instrumentJsFile(helperPath, loggerId, isDryRun, flags);
-      await this.instrumentJsFile(rendererPath, loggerId, isDryRun, flags);
+      await this.instrumentJsFile(controllerPath, loggerId, isDryRun, instrumentationOpts);
+      await this.instrumentJsFile(helperPath, loggerId, isDryRun, instrumentationOpts);
+      await this.instrumentJsFile(rendererPath, loggerId, isDryRun, instrumentationOpts);
     } catch (error) {
-      this.logger.error(`Error processing Aura ${componentName}`, error);
+      this.logger.error(`Error processing Aura component ${componentName}`, error);
+      throw error;
     }
   }
 
-  private async instrumentCmpFile(filePath: string, componentName: string, isDryRun: boolean): Promise<string> {
+  private async instrumentCmpFile(
+    filePath: string,
+    componentName: string,
+    isDryRun: boolean
+  ): Promise<string> {
     if (!fs.existsSync(filePath)) {
       this.logger.warn(`Component file not found: ${filePath}`);
       return 'logger';
     }
 
     this.logger.debug(`Instrumenting component file: ${filePath}`);
-    this.processedFiles++;
+    this.stats.processedFiles++;
+
     let content = await fs.promises.readFile(filePath, 'utf8');
     const originalContent = content;
 
-    const loggerMatch = content.match(loggerComponentRegex);
+    const loggerMatch = content.match(AuraInstrumentationService.LOGGER_COMPONENT_REGEX);
     if (loggerMatch) {
       return loggerMatch[1];
     }
 
-    const lastAttributeMatch = [...content.matchAll(attributeRegex)].pop();
+    const lastAttributeMatch = [...content.matchAll(AuraInstrumentationService.ATTRIBUTE_REGEX)].pop();
     if (lastAttributeMatch) {
       const insertPosition = lastAttributeMatch.index + lastAttributeMatch[0].length;
       const loggerComponent = `\n    <c:rflibLoggerCmp aura:id="logger" name="${componentName}" appendComponentId="false" />`;
@@ -361,9 +380,12 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
     }
 
     if (content !== originalContent) {
-      this.modifiedFiles++;
+      this.stats.modifiedFiles++;
       if (!isDryRun) {
         await fs.promises.writeFile(filePath, content, 'utf8');
+        this.logger.info(`Modified component file: ${filePath}`);
+      } else {
+        this.logger.info(`Would modify component file: ${filePath}`);
       }
     }
 
@@ -374,7 +396,7 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
     filePath: string,
     loggerId: string,
     isDryRun: boolean,
-    flags: InstrumentationFlags,
+    instrumentationOpts: InstrumentationOptions
   ): Promise<void> {
     if (!fs.existsSync(filePath)) {
       this.logger.debug(`JavaScript file not found: ${filePath}`);
@@ -382,33 +404,40 @@ export default class RflibLoggingAuraInstrument extends SfCommand<RflibLoggingAu
     }
 
     this.logger.debug(`Instrumenting JavaScript file: ${filePath}`);
-    this.processedFiles++;
+    this.stats.processedFiles++;
+
     let content = await fs.promises.readFile(filePath, 'utf8');
 
-    // Check if component is already instrumented
-    if (flags.skipInstrumented && RflibLoggingAuraInstrument.isInstrumented(content, loggerId)) {
-      this.logger.info(`Skipping instrumented component: ${filePath}`);
+    if (instrumentationOpts.skipInstrumented && AuraInstrumentationService.isInstrumented(content, loggerId)) {
+      this.logger.info(`Skipping instrumented file: ${filePath}`);
       return;
     }
 
     const originalContent = content;
+    const isHelper = filePath.endsWith('Helper.js');
 
-    const usePrettier = flags.prettier;
-
-    // Process methods
-    content = RflibLoggingAuraInstrument.processMethodLogging(this.logger, content, loggerId, filePath, flags);
-    content = RflibLoggingAuraInstrument.processPromiseChains(content);
-    content = RflibLoggingAuraInstrument.processTryCatchBlocks(content);
+    // Process methods and other patterns
+    content = AuraInstrumentationService.processMethodLogging(
+      content,
+      loggerId,
+      isHelper,
+      instrumentationOpts.noIf
+    );
+    content = AuraInstrumentationService.processPromiseChains(content);
+    content = AuraInstrumentationService.processTryCatchBlocks(content);
 
     if (content !== originalContent) {
-      this.modifiedFiles++;
+      this.stats.modifiedFiles++;
       if (!isDryRun) {
         try {
-          const finalContent = usePrettier ? await prettier.format(content, this.prettierConfig) : content;
+          const finalContent = instrumentationOpts.prettier
+            ? await AuraInstrumentationService.formatContent(content)
+            : content;
+
           await fs.promises.writeFile(filePath, finalContent);
 
-          if (usePrettier) {
-            this.formattedFiles++;
+          if (instrumentationOpts.prettier) {
+            this.stats.formattedFiles++;
             this.logger.info(`Modified and formatted: ${filePath}`);
           } else {
             this.logger.info(`Modified: ${filePath}`);

--- a/src/commands/rflib/logging/lwc/instrument.ts
+++ b/src/commands/rflib/logging/lwc/instrument.ts
@@ -1,43 +1,227 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 /* eslint-disable no-await-in-loop */
-/* eslint-disable @typescript-eslint/quotes */
-/* eslint-disable sf-plugin/no-missing-messages */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, Logger } from '@salesforce/core';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as prettier from 'prettier';
+
+interface InstrumentationOptions {
+  readonly prettier: boolean;
+  readonly noIf: boolean;
+  readonly skipInstrumented: boolean;
+}
+
+interface LoggerInfo {
+  readonly exists: boolean;
+  readonly variableName: string;
+}
+
+interface IfCondition {
+  readonly condition: string;
+  readonly position: number;
+}
+
+export interface RflibLoggingLwcInstrumentResult {
+  processedFiles: number;
+  modifiedFiles: number;
+  formattedFiles: number;
+}
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('rflib-plugin', 'rflib.logging.lwc.instrument');
 
-const importRegex = /import\s*{\s*createLogger\s*}\s*from\s*['"]c\/rflibLogger['"]/;
-const loggerRegex = /const\s+(\w+)\s*=\s*createLogger\s*\(['"]([\w-]+)['"]\)/;
-const methodRegex = /(?:async\s+)?(?!(?:if|switch|case|while|for|catch)\b)(\b\w+)\s*\((.*?)\)\s*{/g;
-const exportDefaultRegex = /export\s+default\s+class\s+(\w+)/;
-const ifStatementRegex = /if\s*\((.*?)\)\s*(?:{([^]*?(?:(?<!{){(?:[^]*?)}(?!})[^]*?)*)}|([^{].*?)(?=\s*(?:;|$));)/g;
-const elseRegex = /}\s*else(?!\s+if\b)\s*(?:{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}|([^{].*?)(?=\n|;|$))/g;
-const promiseChainRegex =
-  /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:\{((?:[^{}]|`[^`]*`)*?)\}|([^{;]*(?:\([^)]*\))*)(?=(?:\)\))|\)|\.))/g;
-const tryCatchBlockRegex = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
+class LwcInstrumentationService {
+  private static readonly IMPORT_REGEX = /import\s*{\s*createLogger\s*}\s*from\s*['"]c\/rflibLogger['"]/;
+  private static readonly LOGGER_REGEX = /const\s+(\w+)\s*=\s*createLogger\s*\(['"]([\w-]+)['"]\)/;
+  private static readonly METHOD_REGEX = /(?:async\s+)?(?!(?:if|switch|case|while|for|catch)\b)(\b\w+)\s*\((.*?)\)\s*{/g;
+  private static readonly EXPORT_DEFAULT_REGEX = /export\s+default\s+class\s+(\w+)/;
+  private static readonly IF_STATEMENT_REGEX = /if\s*\((.*?)\)\s*(?:{([^]*?(?:(?<!{){(?:[^]*?)}(?!})[^]*?)*)}|([^{].*?)(?=\s*(?:;|$));)/g;
+  private static readonly ELSE_REGEX = /}\s*else(?!\s+if\b)\s*(?:{((?:[^{}]|{(?:[^{}]|{[^{}]*})*})*)}|([^{].*?)(?=\n|;|$))/g;
+  private static readonly PROMISE_CHAIN_REGEX = /\.(then|catch|finally)\s*\(\s*(?:async\s+)?(?:\(?([^)]*)\)?)?\s*=>\s*(?:\{((?:[^{}]|`[^`]*`)*?)\}|([^{;]*(?:\([^)]*\))*)(?=(?:\)\))|\)|\.))/g;
+  private static readonly TRY_CATCH_BLOCK_REGEX = /try\s*{[\s\S]*?}\s*catch\s*\(([^)]*)\)\s*{/g;
 
-type IfCondition = {
-  condition: string;
-  position: number;
-};
+  private static readonly PRETTIER_CONFIG: prettier.Options = {
+    parser: 'babel',
+    printWidth: 120,
+    tabWidth: 4,
+    useTabs: false,
+    singleQuote: true,
+  };
 
-type InstrumentationFlags = {
-  prettier: boolean;
-  noIf: boolean;
-  skipInstrumented: boolean;
-};
+  public static async formatContent(content: string): Promise<string> {
+    try {
+      return await prettier.format(content, this.PRETTIER_CONFIG);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Formatting failed: ${error.message}`);
+      }
+      throw new Error('Formatting failed with unknown error');
+    }
+  }
 
-export type RflibLoggingLwcInstrumentResult = {
-  processedFiles: number;
-  modifiedFiles: number;
-  formattedFiles: number;
-};
+  public static isInstrumented(content: string): boolean {
+    return this.IMPORT_REGEX.test(content);
+  }
+
+  public static detectLogger(content: string): LoggerInfo {
+    const match = content.match(this.LOGGER_REGEX);
+    return {
+      exists: match !== null,
+      variableName: match ? match[1] : 'logger',
+    };
+  }
+
+  public static addImportAndLogger(content: string, componentName: string): string {
+    let modified = content;
+
+    if (!this.IMPORT_REGEX.test(content)) {
+      modified = `import { createLogger } from 'c/rflibLogger';\n${modified}`;
+    }
+
+    const { exists, variableName } = this.detectLogger(content);
+    if (!exists) {
+      const exportMatch = content.match(this.EXPORT_DEFAULT_REGEX);
+      const className = exportMatch ? exportMatch[1] : componentName;
+      const loggerDeclaration = `\nconst ${variableName} = createLogger('${className}');\n`;
+      modified = modified.replace(this.EXPORT_DEFAULT_REGEX, `${loggerDeclaration}$&`);
+    }
+
+    return modified;
+  }
+
+  public static processIfStatements(content: string, loggerName: string): string {
+    const conditions: IfCondition[] = [];
+
+    let modified = content.replace(
+      this.IF_STATEMENT_REGEX,
+      (match: string, condition: string, blockBody: string, singleLineBody: string, offset: number) => {
+        const cleanedUpCondition = condition.trim().replaceAll("'", "\\'");
+        conditions.push({ condition: cleanedUpCondition, position: offset });
+
+        const logStatement = `${loggerName}.debug('if (${cleanedUpCondition})');\n        `;
+
+        if (blockBody) {
+          return `if (${condition}) {\n        ${logStatement}${blockBody}}`;
+        } else if (singleLineBody) {
+          const cleanBody = singleLineBody.replace(/;$/, '').trim();
+          return `if (${condition}) {\n        ${logStatement}${cleanBody};\n    }`;
+        }
+        return match;
+      }
+    );
+
+    modified = modified.replace(
+      this.ELSE_REGEX,
+      (match, blockBody, singleLineBody, offset) => {
+        const nearestIf = conditions
+          .filter((c) => c.position <= (offset ?? 0))
+          .reduce((prev, curr) => (!prev || curr.position > prev.position ? curr : prev));
+
+        const logStatement = nearestIf
+          ? `${loggerName}.debug('else for if (${nearestIf.condition})');\n        `
+          : `${loggerName}.debug('else statement');\n        `;
+
+        if (blockBody) {
+          return `} else {\n        ${logStatement}${blockBody}}`;
+        } else if (singleLineBody) {
+          return `} else {\n        ${logStatement}${singleLineBody};\n    }`;
+        }
+        return match;
+      }
+    );
+
+    return modified;
+  }
+
+  public static processMethodLogging(content: string, loggerName: string, options: InstrumentationOptions): string {
+    let modified = content.replace(
+      this.METHOD_REGEX,
+      (match: string, methodName: string, args: string) => {
+        const parameters = args
+          .split(',')
+          .map((p) => p.trim())
+          .filter((p) => p);
+        const placeholders = parameters.map((_, i) => `{${i}}`).join(', ');
+        const logArgs = parameters.length > 0 ? `, ${parameters.join(', ')}` : '';
+
+        return `${match}\n        ${loggerName}.info('${methodName}(${placeholders})'${logArgs});`;
+      }
+    );
+
+    if (!options.noIf) {
+      modified = this.processIfStatements(modified, loggerName);
+    }
+
+    return modified;
+  }
+
+  public static processTryCatchBlocks(content: string, loggerName: string): string {
+    return content.replace(
+      this.TRY_CATCH_BLOCK_REGEX,
+      (match: string, exceptionVar: string, offset: number) => {
+        const methodName = this.findEnclosingMethod(content, offset);
+        const errorVar = exceptionVar.trim().split(' ')[0] || 'error';
+
+        return match.replace(
+          /catch\s*\(([^)]*)\)\s*{/,
+          `catch(${exceptionVar}) {
+            ${loggerName}.error('An error occurred in function ${methodName}()', ${errorVar});`
+        );
+      }
+    );
+  }
+
+  public static processPromiseChains(content: string, loggerName: string): string {
+    return content.replace(
+      this.PROMISE_CHAIN_REGEX,
+      (match, type, param, blockBody, singleLineBody, offset: number) => {
+        const methodName = this.findEnclosingMethod(content, offset);
+        const paramName = typeof param === 'string' ? param.trim() : type === 'then' ? 'result' : 'error';
+        const indentation = match.match(/\n\s*/)?.[0] ?? '\n        ';
+
+        let logStatement: string;
+        switch (type) {
+          case 'then':
+            logStatement = `${loggerName}.info('${methodName}() promise resolved. Result={0}', ${paramName});`;
+            break;
+          case 'catch':
+            logStatement = `${loggerName}.error('An error occurred in function ${methodName}()', ${paramName});`;
+            break;
+          case 'finally':
+            logStatement = `${loggerName}.info('${methodName}() promise chain completed');`;
+            break;
+          default:
+            logStatement = '';
+        }
+
+        if (singleLineBody) {
+          const trimmedBody = (singleLineBody as string).trim();
+          const adjustedBody = trimmedBody.split(')').length > trimmedBody.split('(').length
+            ? trimmedBody.slice(0, -1)
+            : trimmedBody;
+
+          return `.${type}((${paramName}) => {
+            ${logStatement}
+            return ${adjustedBody};
+        }`;
+        }
+
+        if (blockBody) {
+          return `.${type}((${paramName}) => {${indentation}${logStatement}${indentation}${blockBody}}`;
+        }
+
+        return match;
+      }
+    );
+  }
+
+  private static findEnclosingMethod(content: string, position: number): string {
+    const beforeCatch = content.substring(0, position);
+    const methods = [...beforeCatch.matchAll(this.METHOD_REGEX)].reverse();
+    const closestMethod = methods[0];
+    return closestMethod ? closestMethod[1] : 'unknown';
+  }
+}
 
 export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwcInstrumentResult> {
   public static readonly summary = messages.getMessage('summary');
@@ -76,186 +260,17 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
   };
 
   private logger!: Logger;
-  private processedFiles = 0;
-  private modifiedFiles = 0;
-  private formattedFiles = 0;
-
-  private readonly prettierConfig: prettier.Options = {
-    parser: 'babel',
-    printWidth: 120,
-    tabWidth: 4,
-    useTabs: false,
-    singleQuote: true,
+  private readonly stats: RflibLoggingLwcInstrumentResult = {
+    processedFiles: 0,
+    modifiedFiles: 0,
+    formattedFiles: 0,
   };
-
-  private static detectExistingImport(content: string): boolean {
-    return importRegex.test(content);
-  }
-
-  private static detectExistingLogger(content: string): { exists: boolean; loggerName: string } {
-    const match = content.match(loggerRegex);
-    return {
-      exists: match !== null,
-      loggerName: match ? match[1] : 'logger',
-    };
-  }
-
-  private static addImportAndLogger(content: string, componentName: string): string {
-    let modified = content;
-
-    if (!this.detectExistingImport(content)) {
-      modified = `import { createLogger } from 'c/rflibLogger';\n${modified}`;
-    }
-
-    const { exists, loggerName } = this.detectExistingLogger(content);
-    if (!exists) {
-      const exportMatch = content.match(exportDefaultRegex);
-      const className = exportMatch ? exportMatch[1] : componentName;
-      const loggerDeclaration = `\nconst ${loggerName} = createLogger('${className}');\n`;
-      modified = modified.replace(exportDefaultRegex, `${loggerDeclaration}$&`);
-    }
-
-    return modified;
-  }
-
-  private static findEnclosingMethod(content: string, position: number): string {
-    const beforeCatch = content.substring(0, position);
-    const methods = [...beforeCatch.matchAll(methodRegex)].reverse();
-    const closestMethod = methods[0];
-    return closestMethod ? closestMethod[1] : 'unknown';
-  }
-
-  private static processIfStatements(content: string, loggerName: string): string {
-    const conditions: IfCondition[] = [];
-
-    // Process if statements and store conditions with positions
-    let modified = content.replace(
-      ifStatementRegex,
-      (match: string, condition: string, blockBody: string, singleLineBody: string, offset: number) => {
-        const cleanedUpCondition = condition.trim().replaceAll("'", "\\'");
-        conditions.push({
-          condition: cleanedUpCondition,
-          position: offset,
-        });
-
-        const logStatement = `${loggerName}.debug('if (${cleanedUpCondition})');\n        `;
-
-        if (blockBody) {
-          return `if (${condition}) {\n        ${logStatement}${blockBody}}`;
-        } else if (singleLineBody) {
-          const cleanBody = singleLineBody.replace(/;$/, '').trim();
-          return `if (${condition}) {\n        ${logStatement}${cleanBody};\n    }`;
-        }
-        return match;
-      },
-    );
-
-    // Process else blocks using nearest if condition
-    modified = modified.replace(elseRegex, (match, blockBody, singleLineBody, offset) => {
-      // Find last if statement before this else
-      const nearestIf = conditions
-        .filter((c) => c.position <= offset)
-        .reduce((prev, curr) => (!prev || curr.position > prev.position ? curr : prev));
-
-      const logStatement = nearestIf
-        ? `${loggerName}.debug('else for if (${nearestIf.condition})');\n        `
-        : `${loggerName}.debug('else statement');\n        `;
-
-      if (blockBody) {
-        return `} else {\n        ${logStatement}${blockBody}}`;
-      } else if (singleLineBody) {
-        return `} else {\n        ${logStatement}${singleLineBody};\n    }`;
-      }
-      return match;
-    });
-
-    return modified;
-  }
-
-  private static processMethodLogging(content: string, loggerName: string, flags: InstrumentationFlags): string {
-    // First handle methods
-    let modified = content.replace(methodRegex, (match: string, methodName: string, args: string) => {
-      const parameters = args
-        .split(',')
-        .map((p) => p.trim())
-        .filter((p) => p);
-      const placeholders = parameters.map((_, i) => `{${i}}`).join(', ');
-      const logArgs = parameters.length > 0 ? `, ${parameters.join(', ')}` : '';
-
-      return `${match}\n        ${loggerName}.info('${methodName}(${placeholders})'${logArgs});`;
-    });
-
-    // Then handle if statements
-    if (!flags.noIf) {
-      modified = this.processIfStatements(modified, loggerName);
-    }
-
-    return modified;
-  }
-
-  private static processPromiseChains(content: string, loggerName: string): string {
-    return content.replace(promiseChainRegex, (match, type, param, blockBody, singleLineBody, offset: number) => {
-      const methodName = this.findEnclosingMethod(content, offset);
-      const paramName = typeof param === 'string' ? param.trim() : type === 'then' ? 'result' : 'error';
-      const indentation = match.match(/\n\s*/)?.[0] || '\n        ';
-
-      let logStatement;
-      switch (type) {
-        case 'then':
-          logStatement = `${loggerName}.info('${methodName}() promise resolved. Result={0}', ${paramName});`;
-          break;
-        case 'catch':
-          logStatement = `${loggerName}.error('An error occurred in function ${methodName}()', ${paramName});`;
-          break;
-        case 'finally':
-          logStatement = `${loggerName}.info('${methodName}() promise chain completed');`;
-          break;
-        default:
-          logStatement = '';
-      }
-
-      if (singleLineBody) {
-        let trimmedSingleLineBody = (singleLineBody as string).trim();
-        if (trimmedSingleLineBody.split(')').length > trimmedSingleLineBody.split('(').length) {
-          trimmedSingleLineBody = trimmedSingleLineBody.slice(0, -1);
-        }
-
-        return `.${type}((${paramName}) => {
-            ${logStatement}
-            return ${trimmedSingleLineBody};
-        }`;
-      }
-
-      if (blockBody) {
-        return `.${type}((${paramName}) => {${indentation}${logStatement}${indentation}${blockBody}}`;
-      }
-
-      return match;
-    });
-  }
-
-  private static processTryCatchBlocks(content: string, loggerName: string): string {
-    return content.replace(tryCatchBlockRegex, (match: string, exceptionVar: string, offset: number) => {
-      const methodName = this.findEnclosingMethod(content, offset);
-      const errorVar = exceptionVar.trim().split(' ')[0] || 'error';
-
-      return match.replace(
-        /catch\s*\(([^)]*)\)\s*{/,
-        `catch(${exceptionVar}) {
-            ${loggerName}.error('An error occurred in function ${methodName}()', ${errorVar});`,
-      );
-    });
-  }
-
-  private static isInstrumented(content: string): boolean {
-    return importRegex.test(content);
-  }
 
   public async run(): Promise<RflibLoggingLwcInstrumentResult> {
     this.logger = await Logger.child(this.ctor.name);
     const { flags } = await this.parse(RflibLoggingLwcInstrument);
 
-    const instrumentationFlags = {
+    const instrumentationOpts: InstrumentationOptions = {
       prettier: flags.prettier,
       noIf: flags['no-if'],
       skipInstrumented: flags['skip-instrumented'],
@@ -264,22 +279,22 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
     this.log(`Scanning LWC components in ${flags.sourcepath}...`);
 
     this.spinner.start('Running...');
-    await this.processDirectory(flags.sourcepath, flags.dryrun, instrumentationFlags);
+    await this.processDirectory(flags.sourcepath, flags.dryrun, instrumentationOpts);
     this.spinner.stop();
 
-    this.log(`\nInstrumentation complete.`);
-    this.log(`Processed files: ${this.processedFiles}`);
-    this.log(`Modified files: ${this.modifiedFiles}`);
-    this.log(`Formatted files: ${this.formattedFiles}`);
+    this.log('\nInstrumentation complete.');
+    this.log(`Processed files: ${this.stats.processedFiles}`);
+    this.log(`Modified files: ${this.stats.modifiedFiles}`);
+    this.log(`Formatted files: ${this.stats.formattedFiles}`);
 
-    return {
-      processedFiles: this.processedFiles,
-      modifiedFiles: this.modifiedFiles,
-      formattedFiles: this.formattedFiles,
-    };
+    return { ...this.stats };
   }
 
-  private async processDirectory(dirPath: string, isDryRun: boolean, flags: InstrumentationFlags): Promise<void> {
+  private async processDirectory(
+    dirPath: string,
+    isDryRun: boolean,
+    instrumentationOpts: InstrumentationOptions
+  ): Promise<void> {
     const files = await fs.promises.readdir(dirPath);
 
     for (const file of files) {
@@ -287,48 +302,53 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
       const stat = await fs.promises.stat(filePath);
 
       if (stat.isDirectory()) {
-        await this.processDirectory(filePath, isDryRun, flags);
+        await this.processDirectory(filePath, isDryRun, instrumentationOpts);
       } else if (
         file.endsWith('.js') &&
         !path.dirname(filePath).includes('aura') &&
         !path.dirname(filePath).includes('__tests__')
       ) {
-        await this.instrumentLwcFile(filePath, isDryRun, flags);
+        await this.instrumentLwcFile(filePath, isDryRun, instrumentationOpts);
       }
     }
   }
 
-  private async instrumentLwcFile(filePath: string, isDryRun: boolean, flags: InstrumentationFlags): Promise<void> {
+  private async instrumentLwcFile(
+    filePath: string,
+    isDryRun: boolean,
+    instrumentationOpts: InstrumentationOptions
+  ): Promise<void> {
     const componentName = path.basename(path.dirname(filePath));
     this.logger.debug(`Processing LWC: ${componentName}`);
 
-    const usePrettier = flags.prettier;
-
     try {
-      this.processedFiles++;
+      this.stats.processedFiles++;
       let content = await fs.promises.readFile(filePath, 'utf8');
       const originalContent = content;
 
-      if (flags.skipInstrumented && RflibLoggingLwcInstrument.isInstrumented(content)) {
+      if (instrumentationOpts.skipInstrumented && LwcInstrumentationService.isInstrumented(content)) {
         this.logger.info(`Skipping instrumented component: ${componentName}`);
         return;
       }
 
-      const { loggerName } = RflibLoggingLwcInstrument.detectExistingLogger(content);
-      content = RflibLoggingLwcInstrument.addImportAndLogger(content, componentName);
-      content = RflibLoggingLwcInstrument.processMethodLogging(content, loggerName, flags);
-      content = RflibLoggingLwcInstrument.processTryCatchBlocks(content, loggerName);
-      content = RflibLoggingLwcInstrument.processPromiseChains(content, loggerName);
+      const { variableName } = LwcInstrumentationService.detectLogger(content);
+      content = LwcInstrumentationService.addImportAndLogger(content, componentName);
+      content = LwcInstrumentationService.processMethodLogging(content, variableName, instrumentationOpts);
+      content = LwcInstrumentationService.processTryCatchBlocks(content, variableName);
+      content = LwcInstrumentationService.processPromiseChains(content, variableName);
 
       if (content !== originalContent) {
-        this.modifiedFiles++;
+        this.stats.modifiedFiles++;
         if (!isDryRun) {
           try {
-            const finalContent = usePrettier ? await prettier.format(content, this.prettierConfig) : content;
+            const finalContent = instrumentationOpts.prettier
+              ? await LwcInstrumentationService.formatContent(content)
+              : content;
+
             await fs.promises.writeFile(filePath, finalContent);
 
-            if (usePrettier) {
-              this.formattedFiles++;
+            if (instrumentationOpts.prettier) {
+              this.stats.formattedFiles++;
               this.logger.info(`Modified and formatted: ${filePath}`);
             } else {
               this.logger.info(`Modified: ${filePath}`);

--- a/test/commands/rflib/logging/apex/instrument.test.ts
+++ b/test/commands/rflib/logging/apex/instrument.test.ts
@@ -14,59 +14,85 @@ describe('rflib logging apex instrument', () => {
   let testSession: TestSession;
   let testDir: string;
   let sampleClassPath: string;
+  let instrumentedClassPath: string;
   let originalContent: string;
-  let modifiedContent: string;
+  let originalInstrumentedContent: string;
 
   before(async () => {
     testSession = await TestSession.create();
     testDir = path.join(testSession.dir, 'force-app', 'main', 'default', 'classes');
     fs.mkdirSync(testDir, { recursive: true });
 
-    // Copy sample class to test directory
+    // Store paths and original content but don't execute command
     sampleClassPath = path.join(testDir, 'SampleApexClass.cls');
     originalContent = fs.readFileSync(path.join(__dirname, 'sample', 'SampleApexClass.cls'), 'utf8');
-    fs.writeFileSync(sampleClassPath, originalContent);
 
-    // Run command once for all tests
-    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
-    modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+    instrumentedClassPath = path.join(testDir, 'InstrumentedClass.cls');
+    originalInstrumentedContent = fs.readFileSync(path.join(__dirname, 'sample', 'InstrumentedClass.cls'), 'utf8');
+  });
+
+  // Reset the files before each test
+  beforeEach(() => {
+    fs.writeFileSync(sampleClassPath, originalContent);
+    fs.writeFileSync(instrumentedClassPath, originalInstrumentedContent);
   });
 
   after(async () => {
     await testSession?.clean();
   });
 
-  it('should add class level logger declaration', () => {
+  it('should add class level logger declaration', async () => {
+    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+
     expect(modifiedContent).to.include(
-      "private static final rflib_Logger LOGGER = rflib_LoggerUtil.getFactory().createLogger('SampleApexClass');",
+      "private static final rflib_Logger LOGGER = rflib_LoggerUtil.getFactory().createLogger('SampleApexClass');"
     );
   });
 
-  it('should add entry logging to methods with parameters', () => {
+  it('should add entry logging to methods with parameters', async () => {
+    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+
     expect(modifiedContent).to.include("LOGGER.info('getRecords({0}, {1})', new Object[] { filter, limit });");
     expect(modifiedContent).to.include(
       "LOGGER.info('processRecord({0}, {1})', new Object[] { JSON.serialize(record), JSON.serialize(userMap) });",
     );
   });
 
-  it('should add error logging to catch blocks', () => {
+  it('should add error logging to catch blocks', async () => {
+    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+
     expect(modifiedContent).to.include("LOGGER.error('An error occurred in processRecord()', ex);");
   });
 
-  it('should add log statements to simple if blocks', () => {
+  it('should add log statements to simple if blocks', async () => {
+    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+
     expect(modifiedContent).to.include('LOGGER.debug(\'if (filter == null)');
   });
 
-  it('should convert single line if statements to blocks', () => {
+  it('should convert single line if statements to blocks', async () => {
+    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+
     expect(modifiedContent).to.match(/if \(filter == null\) {\s+LOGGER\.debug.*\s+return new List<String>\(\);\s+}/);
   });
 
-  it('should add log statements to if blocks with nested content', () => {
+  it('should add log statements to if blocks with nested content', async () => {
+    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+
     expect(modifiedContent).to.include('LOGGER.debug(\'if (limit > 100)');
     expect(modifiedContent).to.match(/if \(limit > 100\) {\s+LOGGER\.debug.*\s+for \(Integer i = 0; i < 10; i\+\+\)/);
   });
 
-  it('should add log statements to else blocks', () => {
+  it('should add log statements to else blocks', async () => {
+    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+
     expect(modifiedContent).to.include('LOGGER.debug(\'else for if (limit > 50)\')');
     expect(modifiedContent).to.match(/else {\s+LOGGER\.debug.*\s+System.debug\('Small batch'\);\s+}/);
   });
@@ -93,4 +119,20 @@ describe('rflib logging apex instrument', () => {
     expect(contentWithNoIf).not.to.include("LOGGER.debug('else for if");
   });
 
+  it('should skip instrumented classes when skip-instrumented flag is used', async () => {
+    await RflibLoggingApexInstrument.run([
+      '--sourcepath',
+      testDir,
+      '--skip-instrumented'
+    ]);
+
+    const instrumentedContent = fs.readFileSync(instrumentedClassPath, 'utf8');
+    const regularContent = fs.readFileSync(sampleClassPath, 'utf8');
+
+    expect(instrumentedContent).to.equal(originalInstrumentedContent);
+
+    expect(regularContent).not.to.equal(originalContent);
+    expect(regularContent).to.include('rflib_Logger');
+    expect(regularContent).to.include("LOGGER.info('getRecords({0}, {1})', new Object[] { filter, limit });");
+  });
 });

--- a/test/commands/rflib/logging/apex/sample/InstrumentedClass.cls
+++ b/test/commands/rflib/logging/apex/sample/InstrumentedClass.cls
@@ -1,0 +1,7 @@
+public with sharing class InstrumentedClass {
+  private static final rflib_Logger LOGGER = rflib_LoggerUtil.getFactory().createLogger('InstrumentedClass');
+
+  public void doSomething() {
+      System.debug('test');
+  }
+}

--- a/test/commands/rflib/logging/aura/instrument.test.ts
+++ b/test/commands/rflib/logging/aura/instrument.test.ts
@@ -171,4 +171,70 @@ describe('rflib logging aura instrument', () => {
     expect(regularCmpContent).to.include('<c:rflibLoggerCmp');
     expect(regularControllerContent).to.include("logger.info('handleClick({0})', [event])");
   });
+
+  it('should handle mixed instrumentation states when skip-instrumented flag is used', async () => {
+    // Create a directory for the mixed instrumentation component
+    const mixedDir = path.join(sourceDir, 'main', 'default', 'aura', 'mixedComponent');
+    fs.mkdirSync(mixedDir, { recursive: true });
+
+    // Create component files
+    const mixedCmpPath = path.join(mixedDir, 'mixedComponent.cmp');
+    const mixedControllerPath = path.join(mixedDir, 'mixedComponentController.js');
+    const mixedHelperPath = path.join(mixedDir, 'mixedComponentHelper.js');
+
+    // Create component with logger already present
+    const mixedCmpContent = `<aura:component>
+        <aura:attribute name="value" type="String" />
+        <c:rflibLoggerCmp aura:id="logger" name="mixedComponent" appendComponentId="false" />
+    </aura:component>`;
+
+    // Create controller that's already instrumented
+    const instrumentedControllerContent = `({
+        handleClick: function(component, event) {
+            var logger = component.find('logger');
+            logger.info('handleClick({0})', [event]);
+            if (event.getSource()) {
+                logger.debug('if (event.getSource())');
+                component.set('v.value', event.getSource().get('v.value'));
+            }
+        }
+    })`;
+
+    // Create helper that's not instrumented
+    const uninstrumentedHelperContent = `({
+        loadData: function(component, params) {
+            var action = component.get('c.serverAction');
+            action.setParams(params);
+            action.setCallback(this, function(response) {
+                if (response.getState() === "SUCCESS") {
+                    component.set('v.value', response.getReturnValue());
+                }
+            });
+            $A.enqueueAction(action);
+        }
+    })`;
+
+    // Write the files
+    fs.writeFileSync(mixedCmpPath, mixedCmpContent);
+    fs.writeFileSync(mixedControllerPath, instrumentedControllerContent);
+    fs.writeFileSync(mixedHelperPath, uninstrumentedHelperContent);
+
+    // Save original content to verify selective changes
+    const originalControllerContent = fs.readFileSync(mixedControllerPath, 'utf8');
+    const originalHelperContent = fs.readFileSync(mixedHelperPath, 'utf8');
+
+    // Run instrumentation with skip-instrumented flag
+    await RflibLoggingAuraInstrument.run(['--sourcepath', sourceDir, '--skip-instrumented']);
+
+    // Verify controller was skipped (should be unchanged)
+    const finalControllerContent = fs.readFileSync(mixedControllerPath, 'utf8');
+    expect(finalControllerContent).to.equal(originalControllerContent);
+
+    // Verify helper was instrumented (should be changed)
+    const finalHelperContent = fs.readFileSync(mixedHelperPath, 'utf8');
+    expect(finalHelperContent).to.not.equal(originalHelperContent);
+    expect(finalHelperContent).to.include("var logger = component.find('logger')");
+    expect(finalHelperContent).to.include("logger.info('loadData({0}, {1})', [component, params])");
+    expect(finalHelperContent).to.include("logger.debug('if (response.getState() === \"SUCCESS\")')");
+  });
 });

--- a/test/commands/rflib/logging/lwc/sample/instrumented.js
+++ b/test/commands/rflib/logging/lwc/sample/instrumented.js
@@ -1,0 +1,63 @@
+import { LightningElement } from 'lwc';
+
+import { createLogger } from 'c/rflibLogger';
+
+export default class SampleComponent extends LightningElement {
+    isEnabled = false;
+    loading = false;
+    disabled = false;
+    data = null;
+
+    logger = createLogger('MyModule');
+
+    async handleClick(event) {
+      this.logger.info('handleClick: {0}', event);
+        try {
+            const result = await this.loadData();
+            this.processResult(result);
+        } catch(error) {
+            console.error(error);
+        }
+    }
+
+    handleEvent(event) {
+        if (disabled) return;
+
+        if (this.isEnabled) {
+            this.processEvent(event);
+            if (this.loading) {
+                if (this.data) {
+                    this.updateData();
+                }
+            }
+        } else {
+            this.handleError();
+        }
+    }
+
+    loadData() {
+        return fetch('/api/data')
+            .then(response => response.json())
+            .catch(error => {
+                console.error(error);
+            });
+    }
+
+    setTitle() {
+        getCustomSettingLabel({ customSettingsApiName: this.customSettingsApiName })
+            .then((label) => {
+                this.title = `${label} Editor`;
+            })
+            .catch(error => {
+                this.title = 'Custom Settings Editor';
+            });
+    }
+
+    checkUserPermissions() {
+        return canUserModifyCustomSettings({ customSettingsApiName: this.customSettingsApiName })
+            .then(result => {
+                this.canModifySettings = result;
+            }) // checkUserPermissions must complete before the settings are loaded
+            .finally(() => this.loadCustomSettings());
+    }
+}


### PR DESCRIPTION
The `--skip-instrumented` flag provides a way to skip files that already have logging instrumentation in place. Here's what it does across different component types:

For Apex classes:
- Checks for references to `rflib_Logger` in the file
- If found, skips adding any additional logging statements
- Preserves existing logging setup without modification

For Aura components:
- Detects if the `<c:rflibLoggerCmp>` component is already present
- Skips components that already have logging configured
- Leaves existing logger initialization and usage untouched

For LWC components:
- Checks for existing `rflib` logger imports
- If the component already imports and uses the logger, skips instrumentation
- Maintains existing logging patterns without adding duplicates

This flag is particularly useful when:
- Running the instrumentation command multiple times
- Working with partially instrumented codebases
- Wanting to preserve custom logging implementations
- Avoiding duplicate logging statements

The flag helps prevent double-instrumentation and respects existing logging patterns while still allowing new files to be instrumented.