### PR TITLE
feat: Added System.debug to RFLIB Logger Conversion in Apex

### DIFF
--- a/test/commands/rflib/logging/apex/instrument.test.ts
+++ b/test/commands/rflib/logging/apex/instrument.test.ts
@@ -128,7 +128,7 @@ describe('rflib logging apex instrument', () => {
     const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
 
     expect(modifiedContent).to.include('LOGGER.debug(\'else for if (someLimit > 50)\')');
-    expect(modifiedContent).to.match(/else {\s+LOGGER\.debug.*\s+System.debug\('Small batch'\);\s+}/);
+    expect(modifiedContent).to.match(/else {\s+LOGGER\.debug.*\s+LOGGER.debug\('Small batch'\);\s+}/);
   });
 
   it('should skip if statement instrumentation when no-if flag is used', async () => {
@@ -195,5 +195,12 @@ describe('rflib logging apex instrument', () => {
     expect(formattedContent).to.include('if (filter == null) {'); // Single quotes
     expect(result.formattedFiles).to.equal(2);      // The test file should not have been formatted since it is already clean
     expect(result.modifiedFiles).to.equal(3);       // Modified files counter
+  });
+
+  it('should replace System.debug statements with LOGGER.debug', async () => {
+    await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
+
+    expect(modifiedContent).to.include("LOGGER.debug('Medium batch');");
   });
 });

--- a/test/commands/rflib/logging/apex/sample/InstrumentedClass.cls
+++ b/test/commands/rflib/logging/apex/sample/InstrumentedClass.cls
@@ -1,5 +1,5 @@
 public with sharing class InstrumentedClass {
-  private static final rflib_Logger LOGGER = rflib_LoggerUtil.getFactory().createLogger('InstrumentedClass');
+  private static final rflib_Logger MY_LOGGER = rflib_LoggerUtil.getFactory().createLogger('InstrumentedClass');
 
   public void doSomething() {
       System.debug('test');


### PR DESCRIPTION
Automatically converts `System.debug()` calls to use RFLIB logging framework:

1. Identifies `System.debug('message')` statements
2. Uses existing class logger instance
3. Converts to `LOGGER.debug('message')`
4. Preserves message content and formatting
5. Skips conversion in test classes

Changes Made
- Added `SYSTEM_DEBUG_REGEX` pattern
- Added `processSystemDebugStatements` method
- Updated file instrumentation logic
- Added unit tests for conversion
- Updated documentation
- Example Usage
Before:
```
public class MyClass {
    public void doSomething() {
        System.debug('Processing started');
        // ...code...
        System.debug('Processing completed');
    }
}
```
After:
```
public class MyClass {
    private static final rflib_Logger LOGGER = rflib_LoggerUtil.getFactory().createLogger('MyClass');
    
    public void doSomething() {
        LOGGER.debug('Processing started');
        // ...code...
        LOGGER.debug('Processing completed');
    }
}
```