### PR TITLE
feat: Add Console Log to RFLIB Logger Conversion for Aura and LWC

### DIFF
--- a/messages/rflib.logging.aura.instrument.md
+++ b/messages/rflib.logging.aura.instrument.md
@@ -9,6 +9,7 @@ Analyzes Aura Component files and adds RFLIB logging statements for:
 - Error logging in try-catch blocks
 - Error logging in Promise catch handlers
 - Adds rflibLoggerCmp component if not present
+- Replaces console.log and similar method invocations
 - Formats modified files using Prettier (optional)
 
 The command processes:

--- a/messages/rflib.logging.lwc.instrument.md
+++ b/messages/rflib.logging.lwc.instrument.md
@@ -11,6 +11,7 @@ Analyzes Lightning Web Component JavaScript files and adds RFLIB logging stateme
 - Condition logging in if/else blocks
 - Adds logger import if not present
 - Adds logger initialization if not present
+- Replaces console.log and similar method invocations
 - Formats modified files using Prettier (optional)
 
 # flags.sourcepath.summary

--- a/test/commands/rflib/logging/aura/instrument.test.ts
+++ b/test/commands/rflib/logging/aura/instrument.test.ts
@@ -282,4 +282,30 @@ describe('rflib logging aura instrument', () => {
     expect(instrumentedController).to.include("customLogger.debug('if (data.isValid)");
     expect(instrumentedController).to.include("customLogger.debug('else");
   });
+
+  it('should replace console log statements in functions', async () => {
+    await RflibLoggingAuraInstrument.run(['--sourcepath', sourceDir]);
+
+    const sampleController = fs.readFileSync(paths.sample.controller, 'utf8');
+    const sampleHelper = fs.readFileSync(paths.sample.helper, 'utf8');
+
+    expect(sampleController).to.include("logger.debug('This is a console.log message');");
+    expect(sampleController).to.include("logger.info('This is a console.info message');");
+    expect(sampleController).to.include("logger.warn('This is a console.warn message');");
+    expect(sampleController).to.include("logger.error('This is a console.error message');");
+
+    expect(sampleController).to.include('logger.debug(anObject);');
+
+    expect(sampleHelper).to.include("myLogger.debug('This is a console.log message');");
+  });
+
+  it('should replace console log statements in promises', async () => {
+    await RflibLoggingAuraInstrument.run(['--sourcepath', sourceDir]);
+
+    const sampleHelper = fs.readFileSync(paths.sample.helper, 'utf8');
+
+    expect(sampleHelper).to.include('logger.debug("Promise resolved: " + data);');
+    expect(sampleHelper).to.include('logger.error("Promise rejected: " + error);');
+    expect(sampleHelper).to.include('logger.debug("Promise finally");');
+  });
 });

--- a/test/commands/rflib/logging/aura/instrumentedSample/instrumentedSampleController.js
+++ b/test/commands/rflib/logging/aura/instrumentedSample/instrumentedSampleController.js
@@ -19,5 +19,12 @@
     } else { 
       component.set("v.value", null);
     }
+  },
+
+  testConsoleLogReplacement: function(component, event, helper) {
+    console.log('This is a console.log message');
+    console.info('This is a console.info message');
+    console.warn('This is a console.warn message');
+    console.error('This is a console.error message');
   }
 })

--- a/test/commands/rflib/logging/aura/sample/sampleController.js
+++ b/test/commands/rflib/logging/aura/sample/sampleController.js
@@ -13,5 +13,15 @@
         component.set("v.value", data.value);
       else 
         component.set("v.value", null);
+  },
+
+  testConsoleLogReplacement: function(component, event, helper) {
+    console.log('This is a console.log message');
+    console.info('This is a console.info message');
+    console.warn('This is a console.warn message');
+    console.error('This is a console.error message');
+
+    var anObject = {};
+    console.log(anObject);
   }
 })

--- a/test/commands/rflib/logging/aura/sample/sampleHelper.js
+++ b/test/commands/rflib/logging/aura/sample/sampleHelper.js
@@ -15,6 +15,8 @@
           var action = component.get("c.getData");
           action.setParams(params);
           action.setCallback(this, function(response) {
+            
+            console.log("console log message in callback");
               if (response.getState() === "SUCCESS") {
                   resolve(response.getReturnValue());
               } else {
@@ -23,13 +25,20 @@
           });
           $A.enqueueAction(action);
       }).then(function(data) {
-          console.log("Promise resolved: ", data);
+          console.log("Promise resolved: " + data);
           return data;
       }).catch(function(error) {
-          console.error("Promise rejected: ", error);
+          console.error("Promise rejected: " + error);
           throw error;
       }).finally(function() {
           console.log("Promise finally");
       });
+  },
+
+  testConsoleLogReplacementWithExistingLoggerVar: function(component, event, helper) {
+    var myLogger = component.find('logger');
+    myLogger.info('testConsoleLogReplacementWithExistingLoggerVar() invoked');
+    
+    console.log('This is a console.log message');
   }
 })

--- a/test/commands/rflib/logging/lwc/instrument.test.ts
+++ b/test/commands/rflib/logging/lwc/instrument.test.ts
@@ -207,4 +207,18 @@ describe('rflib logging lwc instrument', () => {
     // The previously instrumented file should be modified with additional logging
     expect(instrumentedFileContent).not.to.equal(originalInstrumentedContent);
   });
+
+  it('should replace console log statements in functions', async () => {
+    await RflibLoggingLwcInstrument.run(['--sourcepath', testDir]);
+
+    const sampleController = fs.readFileSync(sampleComponentPath, 'utf8');
+
+    expect(sampleController).to.include("logger.debug('This is a console.log message');");
+    expect(sampleController).to.include("logger.info('This is a console.info message');");
+    expect(sampleController).to.include("logger.warn('This is a console.warn message');");
+    expect(sampleController).to.include("logger.error('This is a console.error message');");
+
+    expect(sampleController).to.include('logger.debug(anObject);');
+    expect(sampleController).to.include('logger.error(error);');
+  });
 });

--- a/test/commands/rflib/logging/lwc/sample/sample.js
+++ b/test/commands/rflib/logging/lwc/sample/sample.js
@@ -56,4 +56,14 @@ export default class SampleComponent extends LightningElement {
             }) // checkUserPermissions must complete before the settings are loaded
             .finally(() => this.loadCustomSettings());
     }
+
+    testConsoleLogReplacement() {
+        console.log('This is a console.log message');
+        console.info('This is a console.info message');
+        console.warn('This is a console.warn message');
+        console.error('This is a console.error message');
+    
+        var anObject = {};
+        console.log(anObject);
+    }
 }


### PR DESCRIPTION
## Description
Automatically converts console.* calls to use RFLIB logging framework in both Aura and LWC components:

## Features
1. Converts console.* statements:
- console.log() → logger.debug()
- console.info() → logger.info()
- console.warn() → logger.warn()
- console.error() → logger.error()
2. Uses existing logger instance
3. Preserves argument content
4. Processes within method scope
5. Maintains code formatting

## Changes Made
- Added CONSOLE_LOG_REGEX pattern
- Added processConsoleStatements method
- Updated method processing logic
- Added unit tests
- Updated documentation

## Example Usage
Before (Aura/LWC):
```
handleClick() {
    console.log('Click event received');
    console.error('Something went wrong: ' + error);
    console.info('Processing complete');
}
```

After (Aura):
```
handleClick: function(component, event) {
    var logger = component.find('logger');
    logger.info('handleClick({0})', [event]);
    logger.debug('Click event received');
    logger.error('Something went wrong: ' + error);
    logger.info('Processing complete');
}
```

After (LWC):
```
handleClick() {
    logger.info('handleClick()');
    logger.debug('Click event received');
    logger.error('Something went wrong: ' + error);
    logger.info('Processing complete');
}
```
