### PR TITLE
Handle LoggingLevel in Apex System.debug instrumentation

### DIFF
--- a/test/commands/rflib/logging/apex/instrument.test.ts
+++ b/test/commands/rflib/logging/apex/instrument.test.ts
@@ -189,10 +189,13 @@ describe('rflib logging apex instrument', () => {
     expect(result.modifiedFiles).to.equal(3); // Modified files counter
   });
 
-  it('should replace System.debug statements with LOGGER.debug', async () => {
+  it('should replace System.debug statements with logger methods', async () => {
     await RflibLoggingApexInstrument.run(['--sourcepath', testDir]);
     const modifiedContent = fs.readFileSync(sampleClassPath, 'utf8');
 
     expect(modifiedContent).to.include("LOGGER.debug('Medium batch');");
+    expect(modifiedContent).to.include("LOGGER.info('Iteration ' + i);");
+    expect(modifiedContent).to.include("LOGGER.info('Medium batch size: ' + someLimit);");
+    expect(modifiedContent).to.include('LOGGER.error(ex);');
   });
 });

--- a/test/commands/rflib/logging/apex/sample/SampleApexClass.cls
+++ b/test/commands/rflib/logging/apex/sample/SampleApexClass.cls
@@ -9,9 +9,11 @@ public with sharing class SampleApexClass {
         if (someLimit > 100) {
             for (Integer i = 0; i < 10; i++) {
                 System.debug('Processing...');
+                System.debug(LoggingLevel.INFO, 'Iteration ' + i);
             }
         } else if (someLimit > 50) {
             System.debug('Medium batch');
+            System.debug(LoggingLevel.INFO, 'Medium batch size: ' + someLimit);
         } else {
             System.debug('Small batch');
         }
@@ -28,6 +30,7 @@ public with sharing class SampleApexClass {
         } catch (Exception ex) {
             // Missing error logging
             System.debug('Error: ' + ex.getMessage());
+            System.debug(LoggingLevel.ERROR, ex);
         }
     }
     


### PR DESCRIPTION
## Summary
- parse `System.debug` calls so both single-argument and LoggingLevel overloads are rewritten to the matching `rflib_Logger` method while preserving complex expressions
- add Apex sample and unit test coverage to confirm INFO and ERROR levels are mapped to `.info` and `.error`

## Testing
- TS_NODE_PROJECT=./tsconfig.json node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js test/commands/rflib/logging/apex/instrument.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6054a3f40832d91b4b82082008875