### PR TITLE
feat: support TypeScript in LWC instrumentation

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -100,7 +100,7 @@ The `transformSystemDebug` method checks if the argument starts with a single qu
 
 ## LWC-Specific Improvements
 
-### 11. Support TypeScript `.ts` files in LWC components
+### 11. Support TypeScript `.ts` files in LWC components (Completed)
 
 **Applies to:** `sf rflib logging lwc instrument`
 **Type:** Functionality

--- a/src/commands/rflib/logging/lwc/instrument.ts
+++ b/src/commands/rflib/logging/lwc/instrument.ts
@@ -32,7 +32,7 @@ class LwcInstrumentationService {
   private static readonly IMPORT_REGEX = /import\s*{\s*createLogger\s*}\s*from\s*['"]c\/rflibLogger['"]/;
   private static readonly LOGGER_REGEX = /const\s+(\w+)\s*=\s*createLogger\s*\(['"]([\w-]+)['"]\)/;
   private static readonly METHOD_REGEX =
-    /(?:async\s+)?(?!(?:if|switch|case|while|for|catch)\b)(?<!(?:const|let|var|function|export|extends|return|new|typeof|delete|await|throw|yield)\s+)(?<![.(!+*\x2F%=<>&|^?:-]\s*)(\b\w+)\s*(?:\((.*?)\)\s*{|=\s*(?:async\s+)?(?!\(\s*(?:async\s+)?\()(?:\((.*?)\)|(\w+))\s*=>\s*{)/g;
+    /(?:(?:public|private|protected)\s+)?(?:async\s+)?(?!(?:if|switch|case|while|for|catch)\b)(?<!(?:const|let|var|function|export|extends|return|new|typeof|delete|await|throw|yield)\s+)(?<![.(!+*\x2F%=<>&|^?:-]\s*)(\b\w+)\s*(?:\((.*?)\)\s*(?::\s*[\w<>[\]]+\s*)?{|=\s*(?:async\s+)?(?!\(\s*(?:async\s+)?\()(?:\((.*?)\)|(\w+))\s*(?::\s*[\w<>[\]]+\s*)?=>\s*{)/g;
   private static readonly EXPORT_DEFAULT_REGEX = /export\s+default\s+class\s+(\w+)/;
   private static readonly IF_STATEMENT_REGEX =
     /if\s*\((.*?)\)\s*(?:{([^]*?(?:(?<!{){(?:[^]*?)}(?!})[^]*?)*)}|([^{].*?)(?=\s*(?:;|$));)/g;
@@ -126,7 +126,7 @@ class LwcInstrumentationService {
       const rawArgs = namedArgs ?? arrowArgsParens ?? arrowArgNoParens ?? '';
       const parameters = rawArgs
         .split(',')
-        .map((p) => p.trim())
+        .map((p) => p.split(':')[0].trim()) // Extract param name, ignore TS types
         .filter((p) => p);
       const placeholders = parameters.map((_, i) => `{${i}}`).join(', ');
       const logArgs = parameters.length > 0 ? `, ${parameters.join(', ')}` : '';
@@ -144,7 +144,7 @@ class LwcInstrumentationService {
   public static processTryCatchBlocks(content: string, loggerName: string): string {
     return content.replace(this.TRY_CATCH_BLOCK_REGEX, (match: string, exceptionVar: string, offset: number) => {
       const methodName = this.findEnclosingMethod(content, offset);
-      const errorVar = exceptionVar.trim().split(' ')[0] || 'error';
+      const errorVar = exceptionVar.split(':')[0].trim().split(' ')[0] || 'error';
 
       return match.replace(
         /catch\s*\(([^)]*)\)\s*{/,
@@ -159,7 +159,8 @@ class LwcInstrumentationService {
       this.PROMISE_CHAIN_REGEX,
       (match, type, param, blockBody, singleLineBody, offset: number) => {
         const methodName = this.findEnclosingMethod(content, offset);
-        const paramName = typeof param === 'string' ? param.trim() : type === 'then' ? 'result' : 'error';
+        const rawParamName = typeof param === 'string' ? param.split(':')[0].trim() : type === 'then' ? 'result' : 'error';
+        const paramName = rawParamName.split(' ')[0]; // handle "result: any" separating by spaces too just in case
         const indentation = match.match(/\n\s*/)?.[0] ?? '\n        ';
 
         let logStatement: string;
@@ -328,7 +329,7 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
 
         const parentDir = path.dirname(filePath);
         if (
-          entry.name.endsWith('.js') &&
+          (entry.name.endsWith('.js') || entry.name.endsWith('.ts')) &&
           !parentDir.includes('aura') &&
           !parentDir.includes('__tests__')
         ) {
@@ -368,6 +369,11 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
       content = LwcInstrumentationService.processConsoleStatements(content, variableName);
 
       if (content !== originalContent) {
+        let currentPrettierConfig = LwcInstrumentationService.PRETTIER_CONFIG;
+        if (filePath.endsWith('.ts')) {
+          currentPrettierConfig = { ...LwcInstrumentationService.PRETTIER_CONFIG, parser: 'babel-ts' };
+        }
+
         await writeInstrumentedFile(
           filePath,
           content,
@@ -377,7 +383,7 @@ export default class RflibLoggingLwcInstrument extends SfCommand<RflibLoggingLwc
           this.stats,
           this.logger,
           (msg) => this.log(msg),
-          LwcInstrumentationService.PRETTIER_CONFIG,
+          currentPrettierConfig,
         );
       }
     } catch (error) {

--- a/test/commands/rflib/logging/lwc/instrument.test.ts
+++ b/test/commands/rflib/logging/lwc/instrument.test.ts
@@ -23,6 +23,10 @@ describe('rflib logging lwc instrument', () => {
   let originalInstrumentedContent: string;
   let originalNavigationMixinContent: string;
   let originalIfConditionContent: string;
+  let originalSampleTsContent: string;
+  let unformattedSampleTsContent: string;
+
+  let sampleTsComponentPath: string;
 
   before(async () => {
     testSession = await TestSession.create();
@@ -31,21 +35,26 @@ describe('rflib logging lwc instrument', () => {
     fs.mkdirSync(path.join(testDir, 'instrumentedComponent'), { recursive: true });
     fs.mkdirSync(path.join(testDir, 'navigationMixinSample'), { recursive: true });
     fs.mkdirSync(path.join(testDir, 'ifConditionSample'), { recursive: true });
+    fs.mkdirSync(path.join(testDir, 'sampleTsComponent'), { recursive: true });
 
     sampleComponentPath = path.join(testDir, 'sampleComponent', 'sampleComponent.js');
     instrumentedComponentPath = path.join(testDir, 'instrumentedComponent', 'instrumentedComponent.js');
     navigationMixinComponentPath = path.join(testDir, 'navigationMixinSample', 'navigationMixinSample.js');
     ifConditionComponentPath = path.join(testDir, 'ifConditionSample', 'ifConditionSample.js');
+    sampleTsComponentPath = path.join(testDir, 'sampleTsComponent', 'sampleTsComponent.ts');
 
     originalSampleContent = fs.readFileSync(path.join(__dirname, 'sample', 'sample.js'), 'utf8');
     originalInstrumentedContent = fs.readFileSync(path.join(__dirname, 'sample', 'instrumented.js'), 'utf8');
     originalNavigationMixinContent = fs.readFileSync(path.join(__dirname, 'sample', 'navigationMixinSample.js'), 'utf8');
     originalIfConditionContent = fs.readFileSync(path.join(__dirname, 'sample', 'ifConditionSample.js'), 'utf8');
+    originalSampleTsContent = fs.readFileSync(path.join(__dirname, 'sample', 'sampleTs.ts'), 'utf8');
+    unformattedSampleTsContent = originalSampleTsContent.replace(/ {4}/g, '  '); // simple unformatting
 
     fs.writeFileSync(sampleComponentPath, originalSampleContent);
     fs.writeFileSync(instrumentedComponentPath, originalInstrumentedContent);
     fs.writeFileSync(navigationMixinComponentPath, originalNavigationMixinContent);
     fs.writeFileSync(ifConditionComponentPath, originalIfConditionContent);
+    fs.writeFileSync(sampleTsComponentPath, originalSampleTsContent);
   });
 
   beforeEach(() => {
@@ -53,6 +62,7 @@ describe('rflib logging lwc instrument', () => {
     fs.writeFileSync(instrumentedComponentPath, originalInstrumentedContent);
     fs.writeFileSync(navigationMixinComponentPath, originalNavigationMixinContent);
     fs.writeFileSync(ifConditionComponentPath, originalIfConditionContent);
+    fs.writeFileSync(sampleTsComponentPath, originalSampleTsContent);
   });
 
   afterEach(function () {
@@ -173,14 +183,15 @@ describe('rflib logging lwc instrument', () => {
   });
 
   it('should format modified files when prettier flag is used', async () => {
+    fs.writeFileSync(sampleTsComponentPath, unformattedSampleTsContent); // Use an unformatted file as a starting point
     const result = await RflibLoggingLwcInstrument.run(['--sourcepath', testDir, '--prettier']);
     const formattedContent = fs.readFileSync(sampleComponentPath, 'utf8');
     expect(formattedContent).to.include("var x = 'format-this';");
     expect(formattedContent).to.match(/\n {4}/); // Check for 4-space indentation
 
-    expect(result.processedFiles).to.equal(4);
-    expect(result.modifiedFiles).to.equal(4);
-    expect(result.formattedFiles).to.equal(4);
+    expect(result.processedFiles).to.equal(5);
+    expect(result.modifiedFiles).to.equal(5);
+    expect(result.formattedFiles).to.equal(5);
   });
 
   it('should skip if statement instrumentation when no-if flag is used', async () => {
@@ -287,5 +298,23 @@ describe('rflib logging lwc instrument', () => {
     expect(modifiedContent).not.to.include("logger.info('isArray(");
     // The actual method should still be instrumented
     expect(modifiedContent).to.include("logger.info('handleEvent({0})', event)");
+  });
+
+  it('should instrument TypeScript files (.ts) accurately', async () => {
+    await RflibLoggingLwcInstrument.run(['--sourcepath', testDir]);
+    const modifiedContent = fs.readFileSync(sampleTsComponentPath, 'utf8');
+
+    // Make sure logger was created
+    expect(modifiedContent).to.include("import { createLogger } from 'c/rflibLogger'");
+    expect(modifiedContent).to.include("const logger = createLogger('SampleTs')");
+
+    // Make sure methods with types are instrumented correctly
+    expect(modifiedContent).to.include("logger.info('initComponent()')");
+    expect(modifiedContent).to.include("logger.info('loadData({0})', param)");
+    expect(modifiedContent).to.include("logger.info('handleClick({0})', event)");
+    expect(modifiedContent).to.include("logger.info('processEvent({0})', event)");
+
+    // Catch blocks
+    expect(modifiedContent).to.include("logger.error('An error occurred in function loadData()', error)");
   });
 });

--- a/test/commands/rflib/logging/lwc/sample/sampleTs.ts
+++ b/test/commands/rflib/logging/lwc/sample/sampleTs.ts
@@ -1,0 +1,67 @@
+/* eslint-disable */
+// Mock LightningElement for tests
+class LightningElement {}
+const api: any = () => {};
+
+export default class SampleTs extends LightningElement {
+  @api
+  title: string = 'Sample Component TS';
+
+  private data: any[] = [];
+  public isEnabled: boolean = false;
+
+  constructor() {
+    super();
+    this.initComponent();
+  }
+
+  connectedCallback() {
+    this.loadData('init');
+  }
+
+  initComponent(): void {
+    const defaultData: any = { id: 1, name: 'Default' };
+    this.data.push(defaultData);
+  }
+
+  public async loadData(param: string): Promise<void> {
+    try {
+      const response = await fetch('/api/data?param=' + param);
+      this.data = (await response.json()) as any;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  handleClick(event: Event): void {
+    if (this.isEnabled) {
+      this.processEvent(event);
+    } else {
+      console.warn('Component is disabled. Ignore click.', event);
+    }
+  }
+
+  private processEvent(event: any) {
+    console.log('Processing event', event);
+    
+    new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        resolve();
+      }, 100);
+    })
+    .then((result: any) => {
+      console.info('Timeout done');
+    })
+    .catch((err: Error) => {
+      console.error('Timeout error');
+    })
+    .finally(() => {
+        console.debug('Finally block');
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this, arrow-body-style
+  public arrowFunction = (val: string): string => {
+      return val.toUpperCase();
+  }
+}


### PR DESCRIPTION
## Summary
- Adds support for TypeScript `.ts` files when instrumenting LWC components with `sf rflib logging lwc instrument`
- Extends the instrumenter to detect and process both `.js` and `.ts` LWC component files
- Adds test coverage with a sample TypeScript LWC component and corresponding test cases

## Test plan
- [ ] Run `yarn test` to verify all unit tests pass
- [ ] Run `yarn test:nuts` to verify NUT tests pass
- [ ] Test manually: `sf rflib logging lwc instrument --sourcepath force-app --dryrun` on a project with TypeScript LWC components
- [ ] Verify `.ts` LWC files are instrumented correctly (logging calls injected)
- [ ] Verify non-LWC `.ts` files are not incorrectly instrumented

🤖 Generated with [Claude Code](https://claude.com/claude-code)