### PR TITLE
ci: opt workflows into Node 24 for JS actions

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -15,8 +15,10 @@ jobs:
     outputs:
       tag: ${{ steps.distTag.outputs.tag }}
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag  }}
       - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@faf1269ce04ec5cde922dfcb0320391b58f3cb02

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Bump `actions/checkout@v3` → `@v4` in `onRelease.yml`
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` on the `getDistTag` and `unit-tests` jobs so Salesforce composite actions (`getPreReleaseTag`, `yarnInstallWithRetries`, `retry`) stop emitting Node 20 deprecation warnings ahead of GitHub's June 2 2026 cutoff
- Reusable `workflow_call` jobs (`npmPublish`, `create-github-release`, `devScriptsUpdate`) cannot receive caller env; their warnings will resolve when [salesforcecli/github-workflows](https://github.com/salesforcecli/github-workflows) updates upstream (latest `main` still pins `actions/github-script@v7`)

## Test plan

- [ ] Push triggers `tests` workflow — `unit-tests` matrix (Node 20/22/24 × ubuntu/windows) still green
- [ ] `unit-tests` job log no longer shows Node 20 deprecation banner for `yarnInstallWithRetries` / `retry`
- [ ] On next release (or `gh workflow run publish -f tag=<tag>`), `getDistTag` log no longer lists `actions/checkout@v3` or `actions/github-script@v7` in the deprecation banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)